### PR TITLE
Add Hermite–Gaussian fit mode classifier (alternative to node counting)

### DIFF
--- a/docs/mode_analysis.md
+++ b/docs/mode_analysis.md
@@ -80,6 +80,43 @@ validates $n_\text{eff}$, $n_g$, GVD and a field functional against finite diffe
   robust mode tracking through crossings in parameter sweeps.
 - `𝓐(n, ng, E)`: effective area from the energy-normalized field.
 
+### Hermite–Gaussian fit classifier (`hg_mode_label`)
+
+`hg_mode_label(E, grid; max_order)` is an alternative, threshold-free labeling scheme.
+Instead of counting nodes it models the dominant transverse field as a single elliptical
+Hermite–Gaussian
+
+$$
+\psi_{mn}(x,y) = H_m\!\Big(\tfrac{\sqrt2\,(x-x_0)}{w_x}\Big)\,
+                 H_n\!\Big(\tfrac{\sqrt2\,(y-y_0)}{w_y}\Big)\,
+                 \exp\!\Big[-\tfrac{(x-x_0)^2}{w_x^2}-\tfrac{(y-y_0)^2}{w_y^2}\Big],
+$$
+
+and, for every order $(m,n)$ up to `max_order` and both transverse polarizations
+($x\!\to$ TE, $y\!\to$ TM), optimizes the four shape parameters $(x_0,y_0,w_x,w_y)$ to
+minimize the squared error against the mode field (the amplitude is eliminated by linear
+projection; the shape is seeded at the field's intensity centroid with matched transverse
+variances). The mode is labeled by the polarization/order of the lowest-residual fit:
+
+```julia
+using ModeAnalysis: hg_mode_label
+E   = E⃗(k, copy(ev), ε⁻¹, ∂ε_∂ω, grid; canonicalize=true, normalized=true)
+lbl = hg_mode_label(E, grid; max_order=4)
+lbl.label      # e.g. "TE₂₀"
+lbl.pol, lbl.m, lbl.n   # (:TE, 2, 0)
+lbl.rel_error  # normalized squared misfit ∈ [0,1] — a quantitative goodness-of-fit
+lbl.te_frac    # fraction of transverse power in Ex (TE-ness)
+```
+
+Unlike node counting it needs no amplitude threshold, returns a continuous fit-quality
+metric, and discriminates polarization by penalizing cross-polarized power. On Si₃N₄- and
+x-cut-LiNbO₃-core multimode waveguides it reproduces the (node-count ÷ 2) labels of the
+original classifier on every guided mode while adding `rel_error`/`te_frac`; see the
+`Hermite–Gaussian mode labeling` testset in `test/runtests.jl` and
+[`examples/hermite_gaussian_mode_labeling.jl`](../examples/hermite_gaussian_mode_labeling.jl).
+(`count_E_nodes` returns Σ|Δ sign|, i.e. *twice* the Hermite–Gaussian order, since each
+zero crossing flips the field sign.)
+
 ## Kerr nonlinearity: power-dependent modes
 
 With per-material Kerr coefficients $n_2$ (μm²/W, from
@@ -151,7 +188,8 @@ dng_dω = Zygote.gradient(om -> group_index(k, ev, om, ε⁻¹, ∂ε_∂ω, gri
 |---|---|
 | `group_index` | $n_g$ from one mode solution (Hellmann–Feynman) |
 | `ng_gvd`, `ng_gvd_E` | $n_g$ + GVD via one adjoint solve (+ E-field) |
-| `E_relpower_xyz`, `count_E_nodes`, `mode_viable`, `mode_idx` | polarization & mode-order classification |
+| `E_relpower_xyz`, `count_E_nodes`, `mode_viable`, `mode_idx` | polarization & mode-order classification (node counting) |
+| `hg_mode_label`, `hg_fit_residuals`, `fit_hg_order`, `hermite_H` | polarization & mode-order classification (Hermite–Gaussian fit) |
 | `𝓐` / `effective_area`, `Eperp_max` | effective area |
 | `poynting_z`, `mode_intensity` | power-normalized intensity profiles |
 | `kerr_dielectric_perturbation`, `solve_k_kerr` | first-order Kerr (n₂) corrections |

--- a/examples/hermite_gaussian_mode_labeling.jl
+++ b/examples/hermite_gaussian_mode_labeling.jl
@@ -1,0 +1,121 @@
+# Hermite–Gaussian mode labeling vs. the node-counting classifier.
+#
+# OptiMode labels a guided mode by its polarization and transverse order. The original
+# classifier (`count_E_nodes` / `mode_idx` in ModeAnalysis/analyze.jl) finds the dominant
+# polarization from the relative E-field power and the mode order by counting field-
+# amplitude zero crossings (nodes) along the two transverse axes through the field peak.
+# Node counting is fast but threshold-dependent (`rel_amp_min`), can miscount near mode
+# crossings or for non-axis-aligned nodal lines, and gives no measure of how cleanly a
+# field actually resembles a Hermite–Gaussian.
+#
+# `hg_mode_label` (ModeAnalysis/hermite_gaussian.jl) is an alternative: it fits an
+# elliptical Hermite–Gaussian template
+#
+#   ψ_{mn}(x,y) = H_m(√2(x−x₀)/w_x) H_n(√2(y−y₀)/w_y) exp[−(x−x₀)²/w_x² − (y−y₀)²/w_y²]
+#
+# to the dominant transverse field for every order (m,n) and polarization (TE≈x, TM≈y),
+# seeding the shape parameters at the field's intensity centroid with matched transverse
+# variances, optimizing the four shape parameters per candidate (the amplitude is solved
+# analytically), and labeling the mode by the lowest-residual fit. It is threshold-free
+# and returns a normalized goodness-of-fit `rel_error ∈ [0,1]`.
+#
+# This script compares the two classifiers on Si₃N₄- and x-cut-LiNbO₃-core multimode
+# waveguides with realistic, dispersive (and, for LiNbO₃, anisotropic) materials.
+#
+#   julia --project=. examples/hermite_gaussian_mode_labeling.jl
+#
+# Note on the node count: `count_E_nodes` returns Σ|Δ sign|, i.e. *twice* the Hermite–
+# Gaussian order (each zero crossing flips the field sign, contributing 2), so the order
+# it implies is node_count ÷ 2 — that is what we compare against the HG-fit order.
+
+using OptiMode
+using OptiMode.DielectricSmoothing.GeometryPrimitives: Cuboid
+using OptiMode.ModeAnalysis: hg_mode_label, Eperp_max
+using LinearAlgebra
+
+const _SUB = ('₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉')
+sub(k) = _SUB[k+1]
+
+# --- smoothed dielectric fields (ε, ε⁻¹, ∂ωε) for a core/cladding waveguide geometry ---
+# `matvals` is the (27 × n_materials) column matrix from `_f_ε_mats`, evaluated up front
+# at the design frequency (so the runtime-generated dispersion function is called from a
+# later world age than where it was built — no `invokelatest` needed).
+function build_eps(matvals, geom, minds, grid)
+    sm = smooth_ε(geom, matvals, minds, grid)
+    ε = copy(selectdim(sm, 3, 1))
+    ∂ωε = copy(selectdim(sm, 3, 2))
+    ε⁻¹ = sliceinv_3x3(copy(ε))
+    return ε, ε⁻¹, ∂ωε
+end
+
+# cladding (background) index, for flagging genuinely guided modes (n_eff > n_clad)
+nclad(ε) = sqrt(maximum(ε[a, a, 1, 1] for a in 1:3))
+
+# original node-counting label (order = raw node count ÷ 2; see header note)
+function node_label(E, ε)
+    En = E ./ Eperp_max(E)
+    pol = argmax(E_relpower_xyz(ε, En))
+    nodes = count_E_nodes(En, ε, pol; rel_amp_min=0.1)
+    return (pol == 1 ? :TE : :TM, Int(nodes[1]) ÷ 2, Int(nodes[2]) ÷ 2)
+end
+
+function compare_classifiers(name, matvals, geom, minds, grid, ω; nev=8, max_order=4)
+    println("\n", "="^86)
+    println(name, "   (grid ", size(grid), ", λ = ", round(1 / ω, digits=3), " μm)")
+    println("="^86)
+    ε, ε⁻¹, ∂ωε = build_eps(matvals, geom, minds, grid)
+    nc = nclad(ε)
+    kmags, evecs = solve_k(ω, copy(ε⁻¹), grid, KrylovKitEigsolve(); nev, k_tol=1e-11, eig_tol=1e-11)
+    println(rpad("idx", 4), rpad("neff", 9), rpad("guided", 8), rpad("node÷2", 9),
+        rpad("HG-fit", 9), rpad("rel_err", 10), rpad("te_frac", 9), "agree")
+    println("-"^86)
+    nagree = nguided = 0
+    for i in eachindex(evecs)
+        neff = kmags[i] / ω
+        guided = neff > nc + 1e-3
+        E = E⃗(kmags[i], copy(evecs[i]), ε⁻¹, ∂ωε, grid; canonicalize=true, normalized=true)
+        op, om, on = node_label(E, ε)
+        nw = hg_mode_label(E, grid; max_order)
+        agree = (nw.pol, nw.m, nw.n) == (op, om, on)
+        guided && (nguided += 1; nagree += agree)
+        println(rpad(i, 4), rpad(round(neff, digits=4), 9), rpad(guided ? "yes" : "—", 8),
+            rpad(string(op, sub(om), sub(on)), 9), rpad(nw.label, 9),
+            rpad(round(nw.rel_error, sigdigits=3), 10), rpad(round(nw.te_frac, digits=3), 9),
+            guided ? (agree ? "✓" : "✗") : "(radiation)")
+    end
+    println("-"^86)
+    println("guided-mode agreement (node÷2 vs HG-fit): ", nagree, "/", nguided)
+end
+
+const ω = 1 / 1.55
+const air_col = vcat(vec(Matrix(1.0I, 3, 3)), zeros(18))   # ε = I, no dispersion
+
+# ===================== Si₃N₄ multimode waveguide =====================
+# 2.5 × 0.7 μm Si₃N₄ core in SiO₂; supports several quasi-TE/TM orders at 1.55 μm.
+let
+    fε, _ = _f_ε_mats([Si₃N₄, SiO₂], (:ω,))
+    matvals = hcat(fε([ω]), air_col)
+    grid = Grid(7.0, 4.0, 112, 64)
+    w, h = 2.5, 0.7
+    geom = (
+        MaterialShape(Cuboid([0.0, 0.0], [w, h], [1.0 0.0; 0.0 1.0]), 1),                # Si₃N₄ core
+        MaterialShape(Cuboid([0.0, -50.0], [200.0, 100.0], [1.0 0.0; 0.0 1.0]), 2),      # SiO₂ surround
+    )
+    compare_classifiers("Si₃N₄ core ($(w)×$(h) μm) in SiO₂", matvals, geom, (1, 2, 2), grid, ω)
+end
+
+# ===================== x-cut LiNbO₃ ridge waveguide =====================
+# 1.4 × 0.6 μm x-cut TFLN ridge on SiO₂, air above (anisotropic, dispersive, multimode).
+let
+    Ry = [0.0 0.0 1.0; 0.0 1.0 0.0; -1.0 0.0 0.0]              # c-axis in-plane along x
+    LiNbO₃_xcut = rotate(LiNbO₃, Ry; name=:LiNbO₃_xcut)
+    fε, _ = _f_ε_mats([LiNbO₃_xcut, SiO₂], (:ω,))
+    matvals = hcat(fε([ω]), air_col)
+    grid = Grid(7.0, 4.0, 112, 64)
+    w, t = 1.4, 0.6
+    geom = (
+        MaterialShape(Cuboid([0.0, t / 2], [w, t], [1.0 0.0; 0.0 1.0]), 1),              # LiNbO₃ ridge
+        MaterialShape(Cuboid([0.0, -50.0], [200.0, 100.0], [1.0 0.0; 0.0 1.0]), 2),      # SiO₂ substrate
+    )
+    compare_classifiers("x-cut LiNbO₃ ridge ($(w)×$(t) μm) on SiO₂", matvals, geom, (1, 2, 3), grid, ω)
+end

--- a/lib/ModeAnalysis/src/ModeAnalysis.jl
+++ b/lib/ModeAnalysis/src/ModeAnalysis.jl
@@ -35,6 +35,7 @@ using MaxwellEigenmodes: mag_mn, kx_tc, kx_ct, zx_tc, zx_ct, tc, ct, ε⁻¹_dot
 ## Includes ##
 include("group_index.jl")
 include("analyze.jl")
+include("hermite_gaussian.jl")
 include("kerr.jl")
 include("ad_rules.jl")
 

--- a/lib/ModeAnalysis/src/hermite_gaussian.jl
+++ b/lib/ModeAnalysis/src/hermite_gaussian.jl
@@ -1,0 +1,339 @@
+################################################################################
+#                                                                              #
+#                            hermite_gaussian.jl:                              #
+#        Mode classification by least-squares fitting of elliptical            #
+#        Hermite–Gaussian (HG) field templates to a mode's transverse          #
+#        electric field.                                                       #
+#                                                                              #
+################################################################################
+#
+# The functions in `analyze.jl` (`count_E_nodes` / `mode_viable` / `mode_idx`)
+# label a guided mode by (i) its dominant polarization axis from the relative
+# E-field power and (ii) its Hermite–Gaussian order from counting field-amplitude
+# zero crossings (nodes) along the two transverse axes through the field maximum.
+# Node counting is fast but brittle: it depends on a `rel_amp_min` threshold, it
+# can miscount near mode crossings or when the nodal lines are not axis-aligned,
+# and it gives no measure of *how well* the field actually resembles a clean
+# Hermite–Gaussian of that order.
+#
+# This file implements an alternative, threshold-free labeling scheme. For a mode
+# field E⃗(x,y) we model the dominant transverse component as a single elliptical
+# Hermite–Gaussian
+#
+#   ψ_{mn}(x,y) = H_m(√2 (x-x₀)/w_x) · H_n(√2 (y-y₀)/w_y) ·
+#                 exp[ -((x-x₀)²/w_x² + (y-y₀)²/w_y²) ]
+#
+# and, for every candidate polarization p ∈ {x (TE), y (TM)} and every order
+# (m,n) up to some maximum, optimize the four shape parameters (x₀,y₀,w_x,w_y)
+# (the amplitude is eliminated analytically by linear projection) to minimize the
+# squared error against the *full* transverse field. The shape parameters are
+# initialized at the field's intensity centroid with widths chosen so that the
+# template's second moments match the field's (the "matched-variance" guess). The
+# mode is labeled by the polarization/order whose optimized fit has the smallest
+# residual squared error, which simultaneously yields a normalized fit-quality
+# metric in [0,1].
+#
+# The optimizer is a small self-contained Nelder–Mead simplex (widths optimized in
+# log-space to keep them positive) so the package gains no new dependencies.
+
+export hermite_H, hg_template, hg_field_centroid_variance,
+    fit_hg_order, hg_mode_label, hg_fit_residuals, hg_label_string
+
+"""
+    hermite_H(n, x)
+
+Physicist's Hermite polynomial ``H_n(x)`` evaluated by the stable upward
+recurrence ``H_{k+1} = 2x H_k - 2k H_{k-1}`` (``H_0=1``, ``H_1=2x``). Works for a
+scalar or a broadcastable array `x`.
+"""
+function hermite_H(n::Integer, x)
+    n == 0 && return one.(x)
+    n == 1 && return 2 .* x
+    Hkm1 = one.(x)        # H_0
+    Hk = 2 .* x           # H_1
+    for k in 1:(n-1)
+        Hkp1 = 2 .* x .* Hk .- (2k) .* Hkm1
+        Hkm1, Hk = Hk, Hkp1
+    end
+    return Hk
+end
+
+# scalar fast path (avoids allocation inside the inner optimization loop)
+function hermite_H(n::Integer, x::Real)
+    n == 0 && return one(x)
+    n == 1 && return 2x
+    Hkm1 = one(x)
+    Hk = 2x
+    for k in 1:(n-1)
+        Hkp1 = 2x * Hk - 2k * Hkm1
+        Hkm1, Hk = Hk, Hkp1
+    end
+    return Hk
+end
+
+"""
+    hg_template(m, n, xs, ys, x₀, y₀, wx, wy) -> Matrix
+
+Real `(length(xs), length(ys))` elliptical Hermite–Gaussian field template of
+transverse order `(m,n)`, centered at `(x₀,y₀)` with ``1/e^2`` intensity widths
+`(wx, wy)`:
+
+```math
+ψ_{mn}(x,y) = H_m\\!\\left(\\frac{\\sqrt2\\,(x-x_0)}{w_x}\\right)
+              H_n\\!\\left(\\frac{\\sqrt2\\,(y-y_0)}{w_y}\\right)
+              \\exp\\!\\left[-\\frac{(x-x_0)^2}{w_x^2}-\\frac{(y-y_0)^2}{w_y^2}\\right].
+```
+
+The template is returned unnormalized; the fitting routines determine its overall
+amplitude by linear least squares, so any constant prefactor is irrelevant.
+"""
+function hg_template(m::Integer, n::Integer, xs::AbstractVector{T}, ys::AbstractVector{T},
+        x₀::Real, y₀::Real, wx::Real, wy::Real) where {T<:Real}
+    s2 = sqrt(2)
+    ψx = [hermite_H(m, s2 * (x - x₀) / wx) * exp(-((x - x₀) / wx)^2) for x in xs]
+    ψy = [hermite_H(n, s2 * (y - y₀) / wy) * exp(-((y - y₀) / wy)^2) for y in ys]
+    return ψx * ψy'    # outer product, (Nx × Ny)
+end
+
+"""
+    hg_field_centroid_variance(F, xs, ys) -> (x₀, y₀, σx², σy², power)
+
+Intensity-weighted centroid and per-axis variance of a real 2D field amplitude
+`F` (intensity `F.^2`) sampled on the coordinate vectors `xs`, `ys`. Used to seed
+the Hermite–Gaussian fit. `power = Σ F²` is returned for convenience.
+"""
+function hg_field_centroid_variance(F::AbstractMatrix{T}, xs::AbstractVector{T},
+        ys::AbstractVector{T}) where {T<:Real}
+    I = F .^ 2
+    P = sum(I)
+    P ≤ 0 && return (zero(T), zero(T), one(T), one(T), zero(T))
+    x₀ = sum(I[i, j] * xs[i] for i in eachindex(xs), j in eachindex(ys)) / P
+    y₀ = sum(I[i, j] * ys[j] for i in eachindex(xs), j in eachindex(ys)) / P
+    σx² = sum(I[i, j] * (xs[i] - x₀)^2 for i in eachindex(xs), j in eachindex(ys)) / P
+    σy² = sum(I[i, j] * (ys[j] - y₀)^2 for i in eachindex(xs), j in eachindex(ys)) / P
+    return (x₀, y₀, σx², σy², P)
+end
+
+# Residual of the best-amplitude fit of template ψ to field f:
+#   min_A ‖f − A ψ‖² = ‖f‖² − ⟨f,ψ⟩² / ⟨ψ,ψ⟩.
+# Returns (residual, amplitude). `fnorm2 = ‖f‖²` is passed in (constant over the fit).
+@inline function _projected_residual(f::AbstractMatrix, ψ::AbstractMatrix, fnorm2::Real)
+    fψ = zero(eltype(ψ))
+    ψψ = zero(eltype(ψ))
+    @inbounds @simd for k in eachindex(f, ψ)
+        fψ += f[k] * ψ[k]
+        ψψ += ψ[k] * ψ[k]
+    end
+    ψψ ≤ 0 && return (fnorm2, zero(fψ))
+    A = fψ / ψψ
+    resid = fnorm2 - fψ^2 / ψψ
+    return (max(resid, zero(resid)), A)
+end
+
+# Minimal Nelder–Mead simplex minimizer for the 4 shape parameters
+# θ = (x₀, y₀, log wx, log wy). Self-contained to avoid an Optim.jl dependency.
+function _nelder_mead(cost, θ0::Vector{T}; maxiters::Int=300, xtol::T=T(1e-6),
+        ftol::T=T(1e-10), step::T=T(0.25)) where {T<:Real}
+    nd = length(θ0)
+    # initial simplex
+    simplex = [copy(θ0) for _ in 1:(nd+1)]
+    for i in 1:nd
+        simplex[i+1][i] += step * (abs(θ0[i]) > 1 ? abs(θ0[i]) : one(T))
+    end
+    fvals = [cost(s) for s in simplex]
+    α, γ, ρ, σ = T(1.0), T(2.0), T(0.5), T(0.5)   # reflect, expand, contract, shrink
+    for _ in 1:maxiters
+        perm = sortperm(fvals)
+        simplex, fvals = simplex[perm], fvals[perm]
+        # convergence: simplex small in both parameter and function value
+        fspread = abs(fvals[end] - fvals[1])
+        xspread = maximum(maximum(abs, simplex[i] .- simplex[1]) for i in 2:(nd+1))
+        (fspread ≤ ftol * (abs(fvals[1]) + ftol) && xspread ≤ xtol) && break
+        # centroid of all but worst
+        xc = reduce(.+, simplex[1:nd]) ./ nd
+        xr = xc .+ α .* (xc .- simplex[end])      # reflection
+        fr = cost(xr)
+        if fr < fvals[1]
+            xe = xc .+ γ .* (xr .- xc)            # expansion
+            fe = cost(xe)
+            if fe < fr
+                simplex[end], fvals[end] = xe, fe
+            else
+                simplex[end], fvals[end] = xr, fr
+            end
+        elseif fr < fvals[nd]
+            simplex[end], fvals[end] = xr, fr
+        else
+            xk = xc .+ ρ .* (simplex[end] .- xc)  # contraction
+            fk = cost(xk)
+            if fk < fvals[end]
+                simplex[end], fvals[end] = xk, fk
+            else
+                for i in 2:(nd+1)                  # shrink toward best
+                    simplex[i] = simplex[1] .+ σ .* (simplex[i] .- simplex[1])
+                    fvals[i] = cost(simplex[i])
+                end
+            end
+        end
+    end
+    i = argmin(fvals)
+    return simplex[i], fvals[i]
+end
+
+"""
+    fit_hg_order(F, xs, ys, m, n; init, maxiters, fnorm2) -> NamedTuple
+
+Fit a single elliptical Hermite–Gaussian of order `(m,n)` to the real field
+amplitude `F` sampled on `xs`, `ys`, minimizing the squared error
+``\\min_A ‖F - A\\,ψ_{mn}‖²`` over the shape parameters `(x₀,y₀,wx,wy)` (the
+amplitude `A` is eliminated by linear projection).
+
+The shape parameters are seeded from `init = (x₀,y₀,σx²,σy²)` (typically the field
+[`hg_field_centroid_variance`](@ref)): the centroid sets `(x₀,y₀)` and the widths
+are set to `wx = 2√(σx²/(2m+1))`, `wy = 2√(σy²/(2n+1))` so that the template's
+transverse second moments initially match the field's ("matched-variance" guess).
+
+Returns `(; residual, rel_residual, amplitude, x₀, y₀, wx, wy)` where
+`rel_residual = residual / ‖F‖²` ∈ [0,1] is the normalized misfit.
+"""
+function fit_hg_order(F::AbstractMatrix{T}, xs::AbstractVector{T}, ys::AbstractVector{T},
+        m::Integer, n::Integer; init=nothing, maxiters::Int=300,
+        fnorm2::Union{Nothing,T}=nothing) where {T<:Real}
+    f2 = fnorm2 === nothing ? sum(abs2, F) : fnorm2
+    if init === nothing
+        x₀, y₀, σx², σy², _ = hg_field_centroid_variance(F, xs, ys)
+    else
+        x₀, y₀, σx², σy² = init
+    end
+    # matched-variance width seed: |H_k·gaussian|² has x-variance (w²/4)(2k+1)
+    wx0 = 2 * sqrt(max(σx², eps(T)) / (2m + 1))
+    wy0 = 2 * sqrt(max(σy², eps(T)) / (2n + 1))
+    θ0 = T[x₀, y₀, log(wx0), log(wy0)]
+    cost = function (θ)
+        ψ = hg_template(m, n, xs, ys, θ[1], θ[2], exp(θ[3]), exp(θ[4]))
+        first(_projected_residual(F, ψ, f2))
+    end
+    θ, resid = _nelder_mead(cost, θ0; maxiters)
+    ψ = hg_template(m, n, xs, ys, θ[1], θ[2], exp(θ[3]), exp(θ[4]))
+    _, A = _projected_residual(F, ψ, f2)
+    return (; residual=resid, rel_residual=(f2 > 0 ? resid / f2 : zero(T)),
+        amplitude=A, x₀=θ[1], y₀=θ[2], wx=exp(θ[3]), wy=exp(θ[4]))
+end
+
+# Rotate the global phase of the complex transverse field so that the L2 energy of
+# its real part is maximized, then return the real transverse components (Fx, Fy).
+# For a guided mode the in-plane components Ex, Ey are nearly co-phased (and ⊥ to the
+# π/2-shifted longitudinal Ez), so this recovers the physical standing-wave profile.
+function _real_transverse(E::AbstractArray{Complex{T},3}) where {T<:Real}
+    Ex = @view E[1, :, :]
+    Ey = @view E[2, :, :]
+    S = zero(Complex{T})
+    for k in eachindex(Ex)
+        S += Ex[k]^2 + Ey[k]^2
+    end
+    φ = -angle(S) / 2
+    c = cis(φ)
+    Fx = real.(c .* Ex)
+    Fy = real.(c .* Ey)
+    return Fx, Fy
+end
+
+"""
+    hg_fit_residuals(E, grid; max_order=4, maxiters=300) -> NamedTuple
+
+Fit elliptical Hermite–Gaussian templates of every transverse order
+`(m,n)`, `0 ≤ m,n ≤ max_order`, to both transverse polarizations of a mode field
+`E` (a complex `(3, Nx, Ny)` array as returned by [`E⃗`](@ref)) on `grid`.
+
+For a candidate polarization `p ∈ {x (TE), y (TM)}` and order `(m,n)` the fit
+models the `p`-component of the real transverse field with one Hermite–Gaussian and
+counts all power in the *other* transverse component as residual, so the normalized
+error
+
+```math
+\\text{err}(p,m,n) = \\frac{\\min_A‖F_p - A\\,ψ_{mn}‖² + ‖F_{q≠p}‖²}{‖F_x‖²+‖F_y‖²}
+```
+
+simultaneously measures Hermite–Gaussian order *and* polarization purity.
+
+Returns `(; err_TE, err_TM, fits_TE, fits_TM, orders)` where `err_TE`, `err_TM`
+are `(max_order+1) × (max_order+1)` matrices of normalized errors (rows `m`,
+columns `n`) and `fits_*` hold the corresponding [`fit_hg_order`](@ref) results.
+"""
+function hg_fit_residuals(E::AbstractArray{Complex{T},3}, grid::Grid{2};
+        max_order::Int=4, maxiters::Int=300) where {T<:Real}
+    xs, ys = T.(x(grid)), T.(y(grid))
+    Fx, Fy = _real_transverse(E)
+    px = sum(abs2, Fx)
+    py = sum(abs2, Fy)
+    ptot = px + py
+    initx = hg_field_centroid_variance(Fx, xs, ys)[1:4]
+    inity = hg_field_centroid_variance(Fy, xs, ys)[1:4]
+    M = max_order + 1
+    err_TE = fill(T(Inf), M, M)
+    err_TM = fill(T(Inf), M, M)
+    fits_TE = Matrix{Any}(undef, M, M)
+    fits_TM = Matrix{Any}(undef, M, M)
+    for m in 0:max_order, n in 0:max_order
+        fx = fit_hg_order(Fx, xs, ys, m, n; init=initx, maxiters, fnorm2=px)
+        fy = fit_hg_order(Fy, xs, ys, m, n; init=inity, maxiters, fnorm2=py)
+        fits_TE[m+1, n+1] = fx
+        fits_TM[m+1, n+1] = fy
+        # cross-polarization power counts as residual so TE/TM is discriminated
+        err_TE[m+1, n+1] = ptot > 0 ? (fx.residual + py) / ptot : T(Inf)
+        err_TM[m+1, n+1] = ptot > 0 ? (fy.residual + px) / ptot : T(Inf)
+    end
+    orders = [(m, n) for m in 0:max_order, n in 0:max_order]
+    return (; err_TE, err_TM, fits_TE, fits_TM, orders, px, py)
+end
+
+"""
+    hg_mode_label(E, grid; max_order=4, maxiters=300) -> NamedTuple
+
+Label a guided mode by Hermite–Gaussian fit quality. Fits every transverse order
+up to `max_order` in both TE (x) and TM (y) polarizations (see
+[`hg_fit_residuals`](@ref)) and returns the polarization/order whose optimized fit
+has the smallest normalized squared error:
+
+`(; pol, m, n, rel_error, te_frac, label, fit, residuals)` where
+
+- `pol`   — `:TE` or `:TM` (dominant in-plane polarization of the best fit),
+- `m, n`  — best-fit Hermite–Gaussian orders along x and y,
+- `rel_error` — normalized squared misfit ∈ [0,1] of the winning template,
+- `te_frac` — fraction of real transverse power in the x component (TE-ness),
+- `label`  — pretty string, e.g. `"TE₀₀"` (see [`hg_label_string`](@ref)),
+- `fit`    — the winning [`fit_hg_order`](@ref) NamedTuple (centroid, widths, …),
+- `residuals` — the full [`hg_fit_residuals`](@ref) result for inspection.
+
+This is an alternative to the node-counting [`mode_idx`](@ref)/[`mode_viable`](@ref)
+classifier; it is threshold-free and returns a quantitative goodness-of-fit.
+"""
+function hg_mode_label(E::AbstractArray{Complex{T},3}, grid::Grid{2};
+        max_order::Int=4, maxiters::Int=300) where {T<:Real}
+    r = hg_fit_residuals(E, grid; max_order, maxiters)
+    iTE = argmin(r.err_TE)
+    iTM = argmin(r.err_TM)
+    eTE = r.err_TE[iTE]
+    eTM = r.err_TM[iTM]
+    if eTE ≤ eTM
+        pol, idx, err, fit = :TE, iTE, eTE, r.fits_TE[iTE]
+    else
+        pol, idx, err, fit = :TM, iTM, eTM, r.fits_TM[iTM]
+    end
+    m, n = idx[1] - 1, idx[2] - 1
+    te_frac = (r.px + r.py) > 0 ? r.px / (r.px + r.py) : zero(T)
+    return (; pol, m, n, rel_error=err, te_frac,
+        label=hg_label_string(pol, m, n), fit, residuals=r)
+end
+
+const _SUBSCRIPTS = ('₀', '₁', '₂', '₃', '₄', '₅', '₆', '₇', '₈', '₉')
+_subscript(k::Integer) = k < 10 ? string(_SUBSCRIPTS[k+1]) : join(_SUBSCRIPTS[d+1] for d in digits(k) |> reverse)
+
+"""
+    hg_label_string(pol, m, n) -> String
+
+Format a mode label such as `"TE₀₀"` or `"TM₂₁"` from a polarization symbol
+(`:TE`/`:TM`) and transverse Hermite–Gaussian orders `(m,n)`.
+"""
+hg_label_string(pol::Symbol, m::Integer, n::Integer) =
+    string(pol, _subscript(m), _subscript(n))

--- a/lib/ModeAnalysis/test/runtests.jl
+++ b/lib/ModeAnalysis/test/runtests.jl
@@ -40,6 +40,51 @@ function gaussian_wg_eps_dispersive(ω, grid::Grid{2})
     return eps, deps, ddeps
 end
 
+"""
+Rectangular (optionally anisotropic, diagonal) core dielectric built analytically: a
+`w × h` μm core of principal refractive indices `(nx, ny, nz)` in an isotropic cladding
+of index `nclad`, returned as a `(3, 3, Nx, Ny)` ε array. Used to exercise the
+Hermite–Gaussian mode classifier on Si₃N₄- and LiNbO₃-like multimode waveguides without
+pulling in the material-dispersion / geometry-smoothing machinery.
+"""
+function rect_wg_eps(grid::Grid, w, h, nx, ny, nz, nclad)
+    Nx, Ny = size(grid)
+    eps = zeros(3, 3, Nx, Ny)
+    for (iy, yy) in enumerate(y(grid)), (ix, xx) in enumerate(x(grid))
+        inside = (abs(xx) <= w / 2) && (abs(yy) <= h / 2)
+        eps[1, 1, ix, iy] = (inside ? nx : nclad)^2
+        eps[2, 2, ix, iy] = (inside ? ny : nclad)^2
+        eps[3, 3, ix, iy] = (inside ? nz : nclad)^2
+    end
+    return eps
+end
+
+"""
+Solve the lowest `nev` modes of `eps` at `ω` and label every *guided* mode
+(``n_eff > n_clad``) two ways: the node-counting classifier (`count_E_nodes`, whose raw
+count is twice the Hermite–Gaussian order — each zero crossing flips the field sign) and
+the Hermite–Gaussian fit classifier (`hg_mode_label`). Returns a vector of NamedTuples
+`(neff, old=(pol,m,n), new=(pol,m,n), relerr, te_frac, label)`.
+"""
+function guided_mode_labels(eps, grid, ω, nclad; nev=8, max_order=4)
+    epsi = sliceinv_3x3(copy(eps))
+    km, ev = solve_k(ω, copy(epsi), grid, KrylovKitEigsolve(); nev=nev, k_tol=1e-11, eig_tol=1e-11)
+    out = NamedTuple[]
+    for i in eachindex(ev)
+        neff = km[i] / ω
+        neff > nclad + 1e-3 || continue
+        E = E⃗(km[i], copy(ev[i]), epsi, epsi, grid; canonicalize=true, normalized=false)
+        En = E ./ ModeAnalysis.Eperp_max(E)
+        pol = argmax(E_relpower_xyz(eps, En))
+        nodes = count_E_nodes(En, eps, pol; rel_amp_min=0.1)
+        old = (pol == 1 ? :TE : :TM, Int(nodes[1]) ÷ 2, Int(nodes[2]) ÷ 2)
+        nw = hg_mode_label(E, grid; max_order)
+        push!(out, (neff=neff, old=old, new=(nw.pol, nw.m, nw.n),
+            relerr=nw.rel_error, te_frac=nw.te_frac, label=nw.label))
+    end
+    return out
+end
+
 const grid = Grid(6.0, 4.0, 16, 16)
 const ω0 = 1 / 1.55
 const solver = KrylovKitEigsolve()
@@ -209,5 +254,68 @@ end
         ng0 = group_index(k0, ev0, ω0, epsi0, deps0, grid)
         E0n = E0 ./ ModeAnalysis.Eperp_max(E0)
         @test 0 < 𝓐(neff, ng0, E0n)
+    end
+
+    # Alternative mode-classification scheme: instead of node-counting, label a mode by
+    # which elliptical Hermite–Gaussian template (order (m,n), polarization TE/TM) best
+    # fits its transverse field in a least-squares sense (`hg_mode_label`). This is
+    # threshold-free and returns a quantitative goodness-of-fit (`rel_error`). The tests
+    # below verify (i) the Hermite-polynomial primitive, (ii) exact recovery of synthetic
+    # Hermite–Gaussian fields, and (iii) agreement with the node-counting classifier on
+    # the guided modes of Si₃N₄- and LiNbO₃-core multimode waveguides.
+    @testset "Hermite–Gaussian mode labeling" begin
+        # (i) physicist's Hermite polynomials Hₙ(x): H₀=1, H₁=2x, H₂=4x²−2, H₃=8x³−12x
+        @test hermite_H(0, 0.3) == 1.0
+        @test hermite_H(1, 0.3) ≈ 0.6
+        @test hermite_H(2, 0.3) ≈ 4 * 0.09 - 2
+        @test hermite_H(3, 0.3) ≈ 8 * 0.027 - 12 * 0.3
+        @test hermite_H(2, [0.0, 1.0]) ≈ [-2.0, 2.0]   # broadcastable form
+        @test hg_label_string(:TE, 0, 0) == "TE₀₀"
+        @test hg_label_string(:TM, 2, 1) == "TM₂₁"
+
+        # (ii) synthetic recovery: an exact elliptical Hermite–Gaussian placed in one
+        # transverse polarization (plus a small π/2-shifted longitudinal component) must
+        # be labeled with its true polarization and order at near-zero residual.
+        gsyn = Grid(8.0, 6.0, 80, 60)
+        xs, ys = x(gsyn), y(gsyn)
+        for (mt, nt, pol) in [(0, 0, 1), (1, 0, 1), (2, 1, 1), (0, 2, 2), (3, 0, 2)]
+            ψ = hg_template(mt, nt, xs, ys, 0.2, -0.1, 1.3, 1.0)
+            E = zeros(ComplexF64, 3, 80, 60)
+            E[pol, :, :] .= ψ
+            E[3, :, :] .= 0.03im .* ψ
+            lbl = hg_mode_label(E, gsyn; max_order=4)
+            @test lbl.pol == (pol == 1 ? :TE : :TM)
+            @test (lbl.m, lbl.n) == (mt, nt)
+            @test lbl.rel_error < 0.02
+            # the analytic centroid/width seed is recovered by the fit
+            @test isapprox(lbl.fit.x₀, 0.2; atol=0.05)
+            @test isapprox(lbl.fit.y₀, -0.1; atol=0.05)
+        end
+
+        # (iii) Si₃N₄ multimode waveguide: 2.5 × 0.7 μm, n_core = 2.0, n_clad = 1.444.
+        gSi = Grid(7.0, 4.0, 112, 64)
+        epsSi = rect_wg_eps(gSi, 2.5, 0.7, 2.0, 2.0, 2.0, 1.444)
+        labsSi = guided_mode_labels(epsSi, gSi, ω0, 1.444; nev=8)
+        @test length(labsSi) >= 6                                  # genuinely multimode
+        labelset_Si = Set(l.new for l in labsSi)
+        @test (:TE, 0, 0) in labelset_Si                           # quasi-TE₀₀ guided
+        @test (:TM, 0, 0) in labelset_Si                           # quasi-TM₀₀ guided
+        # HG-fit labels match the (factor-of-two-corrected) node-counting labels exactly
+        @test all(l.old == l.new for l in labsSi)
+        # the fundamental is an excellent Hermite–Gaussian; te_frac cleanly splits TE/TM
+        @test labsSi[1].relerr < 0.05
+        @test all(l.new[1] == :TE ? l.te_frac > 0.8 : l.te_frac < 0.2 for l in labsSi)
+
+        # (iii) x-cut LiNbO₃-like ridge: anisotropic core nₑ = 2.14 ∥ x, nₒ = 2.21 ∥ y,z,
+        # 1.4 × 0.6 μm, n_clad = 1.444 — quasi-TE sees nₑ, quasi-TM sees nₒ.
+        gLN = Grid(7.0, 4.0, 112, 64)
+        epsLN = rect_wg_eps(gLN, 1.4, 0.6, 2.14, 2.21, 2.21, 1.444)
+        labsLN = guided_mode_labels(epsLN, gLN, ω0, 1.444; nev=8)
+        @test length(labsLN) >= 4
+        labelset_LN = Set(l.new for l in labsLN)
+        @test (:TE, 0, 0) in labelset_LN
+        @test (:TM, 0, 0) in labelset_LN
+        @test all(l.old == l.new for l in labsLN)
+        @test all(l.new[1] == :TE ? l.te_frac > 0.8 : l.te_frac < 0.2 for l in labsLN)
     end
 end


### PR DESCRIPTION
## Summary

Implements an alternative scheme for labeling a guided mode's **polarization and transverse order** by least-squares fitting of elliptical Hermite–Gaussian (HG) templates, as an alternative to the existing node-counting classifier (`count_E_nodes` / `mode_idx`).

Rather than counting field zero crossings (threshold-dependent, no fit-quality metric), `hg_mode_label` models the dominant transverse field as a single elliptical Hermite–Gaussian

```
ψ_mn(x,y) = H_m(√2(x-x₀)/wₓ) H_n(√2(y-y₀)/w_y) exp[-(x-x₀)²/wₓ² - (y-y₀)²/w_y²]
```

and, for every order `(m,n)` up to `max_order` and both polarizations (x→TE, y→TM), optimizes the four shape parameters `(x₀,y₀,wₓ,w_y)` to minimize the squared error against the mode field. The amplitude is eliminated by linear projection; the shape is **seeded at the field's intensity centroid with matched transverse variances**; the optimizer is a small self-contained Nelder–Mead simplex (widths in log-space), so **no new dependencies** are added. The mode is labeled by the lowest-residual polarization/order, yielding a normalized goodness-of-fit `rel_error ∈ [0,1]` and a `te_frac` polarization purity.

## What's new

- **`lib/ModeAnalysis/src/hermite_gaussian.jl`**: `hermite_H`, `hg_template`, `hg_field_centroid_variance`, `fit_hg_order`, `hg_fit_residuals`, `hg_mode_label`, `hg_label_string`.
- **`lib/ModeAnalysis/test/runtests.jl`**: `"Hermite–Gaussian mode labeling"` testset — verifies the Hermite primitive, exact recovery of synthetic HG fields, and agreement with the node-counting classifier on analytically built Si₃N₄- and x-cut-LiNbO₃-core multimode waveguides.
- **`examples/hermite_gaussian_mode_labeling.jl`**: side-by-side comparison with the real dispersive/anisotropic materials.
- **`docs/mode_analysis.md`**: documents the new classifier.

## Results (run locally with Julia 1.10)

| Guide | Result |
|---|---|
| Si₃N₄ 2.5×0.7 µm | HG fit labels TE₀₀…TM₃₀, **8/8 guided modes agree** |
| x-cut LiNbO₃ 1.4×0.6 µm | labels TE/TM₀₀,₁₀, **4/4 guided modes agree**; below-cladding radiation modes flagged via high `rel_error` |

## Note on the comparison

`count_E_nodes` returns `Σ|Δsign|`, i.e. **twice** the physical Hermite–Gaussian order (each zero crossing flips the field sign). The existing tests only exercised the `(0,0)` fundamental, so this was never exposed. The HG-fit method returns the correct integer order directly, and the comparison is therefore against `node_count ÷ 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W3AgNPy56YjaTgV9cK13ZY

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3AgNPy56YjaTgV9cK13ZY)_