### PR TITLE
ModeSweeps: remote SLURM mode solves with blocking/async, PNGs, and remote AD

### DIFF
--- a/docs/mode_sweeps.md
+++ b/docs/mode_sweeps.md
@@ -44,11 +44,108 @@ Key design points:
 
 ## Per-task summaries
 
-Each task × band row contains: the swept parameters, `kmag`, `neff`, `ng` (group
-index), `gvd`, `Aeff`, polarization fractions `pol_x/pol_y/pol_z` (+ dominant
-`pol_axis`), and the Kerr columns `dneff_kerr`, `dn_max` (zero for linear solves).
-Full field data (eigenvectors + E-fields, HDF5) is stored when deployed with
-`save_fields=true` and loaded per task with `load_fields`.
+Each task × band row contains the swept parameters plus quantities **computed on the
+remote worker** from the mode solution:
+
+| group | columns |
+|---|---|
+| dispersion | `kmag`, `neff` (effective index), `ng` (group index), `gvd` |
+| field | `Aeff` (effective area), `pol_x`/`pol_y`/`pol_z` (+ dominant `pol_axis`) |
+| mode character | `label` (e.g. `TE₀₀`), `mode_pol` (`TE`/`TM`), `mode_m`, `mode_n`, `hg_rel_error` (fit goodness), `te_frac` |
+| Kerr | `dneff_kerr`, `dn_max` (zero for linear solves) |
+| execution | `host`, `runtime_s`, `started`, `finished`, `slurm_job`, `slurm_task` |
+
+The mode-character columns come from a threshold-free Hermite–Gaussian fit
+([`hg_mode_label`](mode_analysis.md)); set `mode_labels=false` to skip the fit. This
+lightweight, tabular summary is produced for **every** batch — the full field data
+(eigenvectors + E-fields, HDF5) is stored *additionally* only when deployed with
+`save_fields=true`, and loaded per task with `load_fields`.
+
+## Annotated mode-field images (PNG)
+
+With `save_plots=true`, every worker renders one PNG per band — false-colour
+`|Eₓ|`,`|E_y|`,`|E_z|` panels topped by a header carrying that band's summary
+(`neff`, `ng`, GVD, `Aeff`, polarization, mode label, host, run time) — into the batch's
+`tasks/` directory, and (in ssh mode) transfers them back with the summaries. The
+renderer is **dependency-free** (a small pure-Julia PNG encoder, viridis colormap and
+bitmap font), so PNGs are produced on any SLURM node with no plotting stack or display,
+identically whether the batch keeps full fields or summaries only:
+
+```julia
+batch = frequency_sweep("ridge_wg_setup.jl"; ω=0.55:0.01:0.75, nev=3, save_plots=true,
+                        slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/sw1"))
+wait_batch(batch)                  # block until done (synchronous deployment)
+gather_batch(batch)                # also fetches the PNGs (fetch_plots=true by default)
+plot_paths(batch, 7)               # ["…/task_000007_b01.png", "…_b02.png", "…_b03.png"]
+```
+
+Load the full field data (`load_fields`) into a local Makie/Plots session for
+publication-quality figures; these PNGs are for at-a-glance inspection of a whole sweep.
+
+## Blocking vs. asynchronous deployment
+
+`deploy_batch`/`frequency_sweep` are **asynchronous** by default: they submit and return
+a `BatchInfo` immediately, and you monitor/gather later (from any session). For a
+**blocking** (synchronous) call, pass `blocking=true` (it waits until every task has
+finished before returning) or call `wait_batch` yourself:
+
+```julia
+batch = frequency_sweep("setup.jl"; ω=ωs, blocking=true)   # returns when complete
+rows  = gather_batch(batch)
+
+# or reconnect to a long-running batch from another machine and block on it:
+wait_batch(load_batch("/scratch/me/sw1"); poll=30)
+```
+
+## Remote automatic differentiation (adjoint on the cluster)
+
+The eigensolve `solve_k` carries an adjoint-method `rrule` (see
+[automatic_differentiation.md](automatic_differentiation.md)): given output cotangents
+it returns input cotangents `(ω̄, ε̄⁻¹)` for ≈ one extra eigensolve. ModeSweeps deploys
+the **forward (primal)** and **backward (adjoint)** passes as *separate SLURM tasks* that
+exchange state through the cluster's shared filesystem — so the forward and backward
+solves of an adjoint inverse-design loop can run on different nodes, at different times,
+even driven from different machines:
+
+```mermaid
+flowchart LR
+    A["deploy_forward(setup, p)"] -->|"task: solve_k"| B["tasks/*.fwd.h5<br/>(ω, ε⁻¹, ∂ε_∂ω, grid, k, evecs)"]
+    B --> C["forward_solution → value"]
+    C --> D["objective L(value)<br/>cotangent k̄ = ∂L/∂k"]
+    D --> E["deploy_backward(fwd, [(; k̄)])"]
+    B --> F["task: solve_k adjoint"]
+    E -->|"tasks/*.ct.h5"| F
+    F --> G["tasks/*.bwd.h5 → (ω̄, ε̄⁻¹)"]
+    G --> H["gradient_result"]
+```
+
+```julia
+p   = (; ω = 1/1.55, w_top = 1.7)
+
+# forward pass (its own SLURM task) — primal solution + adjoint inputs on shared FS
+fwd = deploy_forward("ridge_wg_setup.jl", [p]; nev=1, blocking=true,
+                     slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/fwd"))
+sol = forward_solution(fwd)                  # (; ω, kmags, evecs, ε⁻¹, ∂ε_∂ω, grid)
+neff = sol.kmags[1] / sol.ω                  # the value we differentiate
+
+# backward pass (a separate SLURM task) — cotangent k̄ = ∂L/∂kmag for L = neff
+bwd = deploy_backward(fwd, [(; k̄ = [1/sol.ω])]; blocking=true,
+                     slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/bwd"))
+g   = gradient_result(bwd)                   # (; ω_bar, ε⁻¹_bar) = ∂neff/∂(ω, ε⁻¹)
+
+# …or both passes in one blocking call:
+r = remote_value_and_gradient("ridge_wg_setup.jl", p, [1/p.ω]; nev=1,
+                              slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/ad"))
+```
+
+`ε⁻¹_bar` (the sensitivity to every dielectric-tensor entry at every pixel) chains with
+the forward-mode geometry/material Jacobian `∂ε⁻¹/∂p` to give exact geometry/material
+gradients — the standard adjoint pattern for waveguide inverse design, now with the
+expensive solves offloaded to SLURM (see
+[`examples/remote_adjoint_optimization.jl`](../examples/remote_adjoint_optimization.jl)).
+The `k̄`-cotangent path (objectives built from `neff`/`ng`/GVD/`Aeff`, i.e. functions of
+`kmag`) is exact; eigenvector (`ēv`) cotangents are phase-sensitive and best expressed
+through the field post-processing adjoints.
 
 ## Kerr power sweeps
 
@@ -92,7 +189,15 @@ Backends: `backend=:slurm` (default; local `sbatch` or
 |---|---|
 | `param_grid` | Cartesian parameter grids (first keyword varies fastest) |
 | `SlurmConfig` | time/partition/memory/concurrency/ssh options |
-| `deploy_batch`, `frequency_sweep` | create + submit batches |
-| `load_batch`, `batch_status`, `cancel_batch` | persistence & monitoring |
-| `gather_batch`, `save_summary`, `load_summary`, `load_fields` | results |
+| `deploy_batch`, `frequency_sweep` | create + submit batches (`blocking=true` for synchronous) |
+| `load_batch`, `batch_status`, `cancel_batch`, `wait_batch` | persistence & monitoring |
+| `gather_batch`, `save_summary`, `load_summary` | tabular results |
+| `load_fields`, `plot_paths` | full mode fields / annotated PNGs per task |
+| `deploy_forward`, `forward_solution` | remote AD forward pass (primal + adjoint inputs) |
+| `deploy_backward`, `gradient_result`, `remote_value_and_gradient` | remote AD adjoint pass |
+| `render_mode_png`, `write_png` | dependency-free field-image rendering |
 | `run_task` | worker entry point (called by generated `runtask.jl`) |
+
+Deployment options worth knowing: `save_fields` (full HDF5 fields), `save_plots`
+(annotated PNGs), `mode_labels`/`label_max_order` (HG mode classification), `blocking`
+(synchronous), `nev`, `solver`/`solver_kwargs`, `backend`, `slurm`.

--- a/examples/remote_adjoint_optimization.jl
+++ b/examples/remote_adjoint_optimization.jl
@@ -1,0 +1,93 @@
+# Remote, SLURM-managed automatic differentiation of the mode solver.
+#
+# OptiMode's eigensolve `solve_k` carries an adjoint-method `rrule`: given output
+# cotangents it returns input cotangents `(ω̄, ε̄⁻¹)` for ≈ one extra eigensolve,
+# independent of the number of parameters. ModeSweeps runs the **forward (primal)** and
+# **backward (adjoint)** passes as *separate SLURM tasks* that exchange state through the
+# cluster's shared filesystem — so an adjoint-based inverse-design loop can offload both
+# the value and the gradient evaluation to the cluster, even across Julia sessions.
+#
+#     julia --project=. examples/remote_adjoint_optimization.jl
+#
+# As elsewhere, flip `REMOTE` to use ssh+rsync on a real cluster; `:local` runs it all in
+# background processes on one machine.
+
+using OptiMode
+using ModeSweeps
+using ForwardDiff
+using LinearAlgebra: dot
+
+const SETUP = joinpath(@__DIR__, "ridge_wg_setup.jl")
+include(SETUP)                       # make_problem(p) — also used locally below
+
+const REMOTE = false
+slurm = REMOTE ?
+        SlurmConfig(time="0:20:00", partition="general", ssh="me@login.cluster.edu",
+            remote_dir="/scratch/me/ad_ridge") : SlurmConfig()
+backend = REMOTE ? :slurm : :local
+
+# ----------------------------------------------------------------------------------
+# 1. One remote forward + backward pass: ∂neff/∂(ω, ε⁻¹)
+# ----------------------------------------------------------------------------------
+p = (; ω=1 / 1.55, w_top=1.6, h_core=0.7)
+
+# Forward pass as its own SLURM task. Besides the usual summary, it persists everything
+# the adjoint needs — (ω, ε⁻¹, ∂ε_∂ω, grid, kmags, evecs, solver) — to the shared FS.
+fwd = deploy_forward(SETUP, [p]; nev=1, name="adjoint_fwd",
+    solver_kwargs=(; k_tol=1e-10), backend, slurm, blocking=true)
+sol = forward_solution(fwd)                    # (; ω, kmags, evecs, ε⁻¹, ∂ε_∂ω, grid)
+neff = sol.kmags[1] / sol.ω
+@info "forward pass" neff host = "(see summary)"
+
+# Backward pass as a *separate* SLURM task. Our objective is L = neff = kmag/ω, so the
+# cotangent w.r.t. the per-band kmags is k̄ = ∂L/∂kmag = 1/ω.
+bwd = deploy_backward(fwd, [(; k̄=[1 / sol.ω])]; name="adjoint_bwd",
+    backend, slurm, blocking=true)
+g = gradient_result(bwd)                       # (; ω_bar, ε⁻¹_bar)
+@info "backward pass" ∂neff_∂ω = g.ω_bar ‖∂neff_∂ε⁻¹‖ = sqrt(sum(abs2, g.ε⁻¹_bar))
+
+# The same in one blocking call:
+r = remote_value_and_gradient(SETUP, p, [1 / p.ω]; nev=1, name="adjoint_oneshot",
+    solver_kwargs=(; k_tol=1e-10), backend, slurm)
+@info "one-shot value+gradient" neff = r.kmags[1] / p.ω ω_bar = r.ω_bar
+
+# ----------------------------------------------------------------------------------
+# 2. Geometry gradient by the standard hybrid adjoint pattern
+# ----------------------------------------------------------------------------------
+# `ε⁻¹_bar` is the sensitivity of the objective to every inverse-dielectric tensor entry
+# at every pixel. Chaining it with the (cheap, FFT-free) forward-mode geometry Jacobian
+# ∂ε⁻¹/∂(geometry) gives the exact geometry gradient — the eigensolve and its adjoint
+# stay on the cluster, only the smoothing Jacobian is differentiated locally.
+#
+#   ∂neff/∂w_top = vec(ε⁻¹_bar) · ∂vec(ε⁻¹)/∂w_top
+geom_to_epsinv(w) = vec(make_problem((; p.ω, w_top=w, p.h_core)).ε⁻¹)   # ForwardDiff-friendly
+J = ForwardDiff.derivative(geom_to_epsinv, p.w_top)                     # ∂vec(ε⁻¹)/∂w_top
+∂neff_∂w_top = dot(vec(g.ε⁻¹_bar), J)
+@info "geometry gradient (remote adjoint × local forward Jacobian)" ∂neff_∂w_top
+
+# Finite-difference sanity check of the geometry gradient (re-solves locally):
+function neff_local(w)
+    pr = make_problem((; p.ω, w_top=w, p.h_core))
+    k, _ = solve_k(p.ω, copy(pr.ε⁻¹), pr.grid, KrylovKitEigsolve(); nev=1, k_tol=1e-10)
+    return k[1] / p.ω
+end
+δ = 1e-3
+fd = (neff_local(p.w_top + δ) - neff_local(p.w_top - δ)) / (2δ)
+@info "vs. finite difference" fd rel_error = abs(∂neff_∂w_top - fd) / abs(fd)
+
+# ----------------------------------------------------------------------------------
+# 3. Batched gradients (one forward/backward task per design point)
+# ----------------------------------------------------------------------------------
+# `deploy_forward`/`deploy_backward` take whole parameter lists, so a population of
+# designs (e.g. a generation in an optimizer, or a stencil of finite-difference points)
+# is one array job each. Each backward task reads its matching forward state and writes
+# its own (ω̄, ε̄⁻¹).
+designs = [(; ω=1 / 1.55, w_top=w, h_core=0.7) for w in [1.4, 1.6, 1.8, 2.0]]
+fwds = deploy_forward(SETUP, designs; nev=1, name="pop_fwd", backend, slurm, blocking=true)
+cots = [(; k̄=[1 / forward_solution(fwds, i).ω]) for i in 1:length(designs)]   # ∂neff/∂kmag
+bwds = deploy_backward(fwds, cots; name="pop_bwd", backend, slurm, blocking=true)
+grads = [gradient_result(bwds, i) for i in 1:length(designs)]
+for (d, gi) in zip(designs, grads)
+    println("w_top=", d.w_top, "  ∂neff/∂ω=", round(gi.ω_bar, digits=4),
+        "  ‖∂neff/∂ε⁻¹‖=", round(sqrt(sum(abs2, gi.ε⁻¹_bar)), digits=4))
+end

--- a/examples/remote_mode_solve.jl
+++ b/examples/remote_mode_solve.jl
@@ -1,0 +1,96 @@
+# Remote, SLURM-managed mode solves & sweeps with ModeSweeps.
+#
+# This walkthrough shows how to deploy mode-solver jobs to a remote SLURM cluster
+# (blocking and asynchronously), monitor and gather them from any Julia session or
+# machine, choose between lightweight tabular summaries and full field data, and collect
+# the annotated PNG mode-field images rendered on the workers. Everything transfers over
+# rsync; the batch directory is fully self-describing, so you can disconnect and pick the
+# batch back up later from a different computer.
+#
+# Run the heavy parts on a login node that can `sbatch`, or set `backend=:local` to try
+# the whole machinery on your laptop (small grids recommended).
+#
+#     julia --project=. examples/remote_mode_solve.jl
+#
+# Prerequisite: the cluster has this project instantiated on a filesystem shared with the
+# compute nodes (so the workers can `using OptiMode`).
+
+using OptiMode                       # re-exports ModeSweeps
+using ModeSweeps
+
+const SETUP = joinpath(@__DIR__, "ridge_wg_setup.jl")
+
+# Pick a backend. On a real cluster use ssh+rsync; `:local` runs background processes.
+const REMOTE = false                 # flip to true on a login node / with ssh access
+slurm = REMOTE ?
+        SlurmConfig(time="0:30:00", partition="general", mem="8G", cpus_per_task=4,
+            max_concurrent=50, ssh="me@login.cluster.edu", remote_dir="/scratch/me/sw_ridge") :
+        SlurmConfig()
+backend = REMOTE ? :slurm : :local
+
+# ----------------------------------------------------------------------------------
+# 1. Asynchronous deployment of a frequency × geometry sweep
+# ----------------------------------------------------------------------------------
+# `frequency_sweep` builds the Cartesian product of the swept parameters (ω varies
+# fastest) and submits one SLURM array task per parameter set. It returns immediately —
+# the jobs run in the background on the cluster.
+batch = frequency_sweep(SETUP;
+    ω=0.55:0.01:0.75,              # frequency sweep (μm⁻¹); λ = 1/ω from 1.33 to 1.82 μm
+    w_top=[1.2, 1.6, 2.0],         # geometry sweep: core width (μm)
+    h_core=0.7,                    # fixed core height (μm)
+    nev=3,                         # 3 bands per task
+    save_fields=false,             # summary-only (set true to also keep eigenvectors+fields)
+    save_plots=true,               # render an annotated PNG per mode field on the worker
+    mode_labels=true,              # classify each mode (TE₀₀, TM₁₀, …) via Hermite–Gaussian fit
+    solver="KrylovKitEigsolve()",  # worker-side eigensolver (string; e.g. "GPUSolver(Float32)")
+    solver_kwargs=(; k_tol=1e-9),
+    backend, slurm)
+
+@info "submitted" batch
+
+# ----------------------------------------------------------------------------------
+# 2. Monitor & gather — works at any time, from any session/machine
+# ----------------------------------------------------------------------------------
+# In a *fresh* Julia session (even on another computer that mounts the same scratch),
+# re-attach to the batch by directory and inspect progress:
+#
+#     batch = load_batch("/scratch/me/sw_ridge")
+#     batch_status(batch)        # done/failed/pending (+ live squeue lines)
+#
+# Partial gathering is race-free while the batch is still running:
+rows = gather_batch(batch; partial=true)     # rsyncs summaries+PNGs back; writes summary.{csv,tsv,json}
+@info "gathered so far" n = length(rows)
+
+# Each row carries the worker-computed quantities. For example, the fundamental quasi-TE
+# mode of the widest waveguide across the frequency sweep:
+te00 = filter(r -> r.status == "done" && r.w_top == 2.0 && startswith(r.label, "TE"), rows)
+for r in sort(te00; by=r -> r.ω)
+    println("λ=", round(1 / r.ω, digits=3), " μm  ", r.label,
+        "  neff=", round(r.neff, digits=4), "  ng=", round(r.ng, digits=4),
+        "  GVD=", round(r.gvd, digits=2), "  Aeff=", round(r.Aeff, digits=3), " μm²",
+        "  [", r.host, ", ", r.runtime_s, " s]")
+end
+
+# The annotated PNG of each mode field (rendered on the worker, transferred back):
+@info "PNGs for task 1" plot_paths(batch, 1)
+
+# `rows` is a Tables.jl row table — `using DataFrames; DataFrame(rows)` just works, as
+# does `CSV.write("ridge.csv", rows)` or reloading later with `load_summary(path)`.
+
+# ----------------------------------------------------------------------------------
+# 3. Blocking (synchronous) deployment
+# ----------------------------------------------------------------------------------
+# Sometimes you just want to wait. `blocking=true` deploys and returns only once every
+# task has finished; equivalently call `wait_batch` on a handle (e.g. after reconnecting
+# from another machine with `load_batch`).
+batch2 = deploy_batch(SETUP, param_grid(ω=1 / 1.55, w_top=[1.4, 1.8]);
+    name="ridge_blocking", nev=2, save_fields=true, save_plots=true,
+    backend, slurm, blocking=true)
+rows2 = gather_batch(batch2)
+@info "blocking batch complete" n = length(rows2)
+
+# Full field data (only for batches deployed with save_fields=true): eigenvectors and
+# E-fields per band, fetched on demand (large) and loaded per task.
+gather_batch(batch2; fetch_fields=true)        # transfer the HDF5 field files in ssh mode
+fd = load_fields(batch2, 1)                    # (; ω, kmags, evecs, Es, grid_Δ, grid_N)
+@info "loaded full fields" task = 1 bands = length(fd.evecs) Esize = size(first(fd.Es))

--- a/examples/ridge_wg_setup.jl
+++ b/examples/ridge_wg_setup.jl
@@ -1,0 +1,33 @@
+# ModeSweeps problem-setup script: a Si₃N₄ rectangular-ridge waveguide in SiO₂.
+#
+# A setup script maps one parameter set `p::NamedTuple` to the smoothed inverse
+# dielectric tensor and its frequency derivatives on a spatial grid. It is copied into
+# the batch directory and `include`d by every worker (inside a fresh module with the
+# OptiMode component packages already loaded), so it must `using` whatever it needs and
+# define `make_problem`.
+#
+# By convention `p.ω` is the optical frequency (μm⁻¹); here we also sweep the core width
+# `w_top` and (optionally) height `h_core`. Returning `∂²ε_∂ω²` enables group-velocity
+# dispersion (GVD) in the summary. Used by `remote_mode_solve.jl` and
+# `remote_adjoint_optimization.jl`.
+
+using OptiMode.DielectricSmoothing.GeometryPrimitives: Cuboid
+
+function make_problem(p)
+    w_top = haskey(p, :w_top) ? p.w_top : 1.6
+    h_core = haskey(p, :h_core) ? p.h_core : 0.7
+    grid = Grid(6.0, 4.0, 128, 96)
+
+    f_ε, _ = _f_ε_mats([Si₃N₄, SiO₂], (:ω,))
+    mat_vals = f_ε([p.ω])
+    core = MaterialShape(Cuboid([0.0, 0.0], [w_top, h_core], [1.0 0.0; 0.0 1.0]), 1)
+    shapes, minds = (core,), (1, 2)
+
+    sm = smooth_ε(shapes, mat_vals, minds, grid)   # slices: ε, ∂ωε, ∂²ωε
+    return (;
+        ε⁻¹=sliceinv_3x3(copy(selectdim(sm, 3, 1))),
+        ∂ε_∂ω=copy(selectdim(sm, 3, 2)),
+        ∂²ε_∂ω²=copy(selectdim(sm, 3, 3)),
+        grid,
+    )
+end

--- a/lib/ModeSweeps/Project.toml
+++ b/lib/ModeSweeps/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DielectricSmoothing = "2d86eedb-d1a5-44a2-91eb-7a4f4d6f578c"
 HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
@@ -26,6 +27,7 @@ MaxwellEigenmodes = {path = "../MaxwellEigenmodes"}
 ModeAnalysis = {path = "../ModeAnalysis"}
 
 [compat]
+ChainRulesCore = "1"
 julia = "1.10"
 
 [extras]

--- a/lib/ModeSweeps/README.md
+++ b/lib/ModeSweeps/README.md
@@ -1,9 +1,29 @@
 # ModeSweeps.jl
 
-Batched, asynchronous deployment of OptiMode mode simulations — parameter sweeps run
-as SLURM array jobs on a cluster with the same packages installed (or as local
-background processes), with persistent batch state, live status, partial gathering,
-and tabular result I/O.
+Batched, **blocking or asynchronous** deployment of OptiMode mode simulations on a
+remote SLURM cluster (or local background processes) — parameter sweeps run as SLURM
+array jobs, with persistent batch state, live status, partial gathering across Julia
+sessions and machines, rsync data transfer, and tabular result I/O. It also renders
+**annotated PNG mode-field images** on the worker, and supports **remote automatic
+differentiation** (forward & adjoint passes as separate SLURM tasks).
+
+Highlights:
+
+- **Lightweight summaries or full data.** Every batch produces a tabular summary
+  (effective/group index, GVD, effective area, polarization, mode-character label,
+  run time, host, …) computed on the worker; `save_fields=true` additionally keeps the
+  full eigenvectors + E-fields (HDF5).
+- **Annotated field PNGs** (`save_plots=true`) rendered on the worker — dependency-free,
+  so they work on any headless node — and transferred back in either case.
+- **Blocking or async.** `blocking=true` (or `wait_batch`) waits for completion; the
+  default returns immediately and you monitor/gather later from any session.
+- **Remote AD.** `deploy_forward`/`deploy_backward` run the mode solver and its adjoint
+  as different SLURM tasks, exchanging state on the shared filesystem.
+- **rsync transfer** of summaries, PNGs, and (on demand) field/AD data in ssh mode.
+
+Full walkthroughs: [`docs/mode_sweeps.md`](../../docs/mode_sweeps.md),
+[`examples/remote_mode_solve.jl`](../../examples/remote_mode_solve.jl), and
+[`examples/remote_adjoint_optimization.jl`](../../examples/remote_adjoint_optimization.jl).
 
 ## Quick start
 
@@ -21,29 +41,47 @@ batch = frequency_sweep("ridge_wg_setup.jl";
     T      = 35.0,                     # fixed material parameter
     nev    = 2,
     save_fields = false,               # summary-only transfer (set true for full fields)
+    save_plots  = true,                # annotated PNG per mode field, transferred back
+    blocking    = false,               # async (default); blocking=true waits for completion
     solver = "KrylovKitEigsolve()",    # or e.g. "GPUSolver(Float32)"
-    slurm  = SlurmConfig(time="0:30:00", partition="general", max_concurrent=50))
+    slurm  = SlurmConfig(time="0:30:00", partition="general", max_concurrent=50,
+                         ssh="me@cluster", remote_dir="/scratch/me/sw1"))  # rsync transfer
 
 # … or with explicit parameter sets / Cartesian grids:
 batch = deploy_batch("ridge_wg_setup.jl", param_grid(ω=ωs, w_top=ws); nev=2)
 batch = deploy_batch("ridge_wg_setup.jl", [(; ω=0.64, w_top=1.7), (; ω=0.66, w_top=1.4)])
 
-# 3. anytime, in any Julia session:
-batch = load_batch("modesweeps_freq_sweep")     # state persisted at deployment
+# 3. anytime, in any Julia session / on any machine:
+batch = load_batch("/scratch/me/sw1")           # state persisted at deployment
 batch_status(batch)                             # done/failed/pending + squeue info
+wait_batch(batch)                               # (optional) block until complete
 rows  = gather_batch(batch)                     # partial results OK while running;
-                                                # writes summary.{csv,tsv,json}
-rows  = load_summary("modesweeps_freq_sweep/summary.csv")  # reload for analysis
+                                                # rsyncs summaries+PNGs, writes summary.{csv,tsv,json}
+rows  = load_summary("/scratch/me/sw1/summary.csv")   # reload for analysis
 
-# full mode-field data (batches deployed with save_fields=true)
-fd = load_fields(batch, 7)                      # (; ω, kmags, evecs, Es, …)
+fd  = load_fields(batch, 7)                     # full fields (save_fields=true): (; ω, kmags, evecs, Es, …)
+png = plot_paths(batch, 7)                       # annotated PNGs (save_plots=true), one per band
 ```
 
 Each summary row holds the swept parameters plus, per band: wavenumber `kmag`,
 effective index `neff`, group index `ng`, group velocity dispersion `gvd`, effective
-area `Aeff`, polarization fractions `pol_x`/`pol_y`/`pol_z` with the dominant
-`pol_axis`, and the Kerr columns `dneff_kerr`/`dn_max` (zero for linear solves). Rows
-are Tables.jl-compatible (`DataFrame(rows)` just works).
+area `Aeff`, polarization fractions `pol_x`/`pol_y`/`pol_z` (+ dominant `pol_axis`),
+the mode-character label (`label`/`mode_pol`/`mode_m`/`mode_n`/`hg_rel_error`/`te_frac`),
+the Kerr columns `dneff_kerr`/`dn_max` (zero for linear solves), and execution metadata
+(`host`, `runtime_s`, `started`, `finished`, `slurm_job`, `slurm_task`). Rows are
+Tables.jl-compatible (`DataFrame(rows)` just works).
+
+**Remote automatic differentiation.** Run the mode solver and its adjoint as separate
+SLURM tasks that exchange state on the shared filesystem:
+
+```julia
+fwd = deploy_forward("ridge_wg_setup.jl", [(; ω=1/1.55, w_top=1.7)]; nev=1, blocking=true)
+sol = forward_solution(fwd)                                  # primal: (; ω, kmags, evecs, ε⁻¹, …)
+bwd = deploy_backward(fwd, [(; k̄=[1/sol.ω])]; blocking=true) # objective L = neff = kmag/ω
+g   = gradient_result(bwd)                                   # (; ω_bar, ε⁻¹_bar) = ∂L/∂(ω, ε⁻¹)
+# …or both passes in one blocking call:
+r   = remote_value_and_gradient("ridge_wg_setup.jl", (; ω=1/1.55, w_top=1.7), [1/(1/1.55)]; nev=1)
+```
 
 **Kerr power sweeps**: if `make_problem` returns an `n₂` map (μm²/W, e.g. from
 `DielectricSmoothing.smooth_scalar` + `MaterialDispersion.kerr_n2`), any parameter set

--- a/lib/ModeSweeps/src/ModeSweeps.jl
+++ b/lib/ModeSweeps/src/ModeSweeps.jl
@@ -9,6 +9,7 @@
 module ModeSweeps
 
 using Dates
+using Dates: DateTime
 using Printf
 using TOML
 using Serialization
@@ -18,6 +19,8 @@ using Tables
 using HDF5
 using LinearAlgebra
 using Logging
+using ChainRulesCore
+using ChainRulesCore: rrule, ZeroTangent, NoTangent
 
 using MaterialDispersion
 using DielectricSmoothing
@@ -25,13 +28,18 @@ using MaxwellEigenmodes
 using ModeAnalysis
 
 export param_grid, SlurmConfig
-export deploy_batch, frequency_sweep, load_batch, batch_status, cancel_batch
-export gather_batch, save_summary, load_summary, load_fields
-export run_task
+export deploy_batch, frequency_sweep, load_batch, batch_status, cancel_batch, wait_batch
+export gather_batch, save_summary, load_summary, load_fields, plot_paths
+export run_task, render_mode_png, write_png
+# remote automatic differentiation (forward / backward passes as SLURM tasks)
+export deploy_forward, forward_solution, deploy_backward, gradient_result,
+    remote_value_and_gradient
 
 include("params.jl")
+include("render.jl")
 include("batch.jl")
 include("worker.jl")
+include("adjoint.jl")
 include("status.jl")
 include("gather.jl")
 

--- a/lib/ModeSweeps/src/adjoint.jl
+++ b/lib/ModeSweeps/src/adjoint.jl
@@ -1,0 +1,320 @@
+# Remote, SLURM-friendly automatic differentiation of the mode solver.
+#
+# The expensive eigensolve `solve_k` carries an adjoint-method `rrule` (in
+# MaxwellEigenmodes): given output cotangents `(k̄mags, ēvecs)` it returns input
+# cotangents `(ω̄, ε̄⁻¹)` for ≈ one extra eigensolve, independent of the number of
+# parameters. We expose this across the SLURM boundary by splitting the forward (primal)
+# and backward (adjoint) passes into *separate tasks* that communicate through the
+# cluster's shared filesystem:
+#
+#   forward task  (kind="forward")  : solve_k(ω, ε⁻¹, grid, solver) → (kmags, evecs),
+#                                     persist (ω, ε⁻¹, ∂ε_∂ω, grid, kmags, evecs, solver)
+#                                     to  tasks/task_NNNNNN.fwd.h5  (the adjoint inputs),
+#                                     plus the usual summary / fields / PNGs.
+#   backward task (kind="backward") : load that forward state from the (shared) forward
+#                                     batch directory + the user-supplied output
+#                                     cotangents (tasks/task_NNNNNN.ct.h5), run the
+#                                     `solve_k` adjoint, and write the input cotangents
+#                                     (ω̄, ε̄⁻¹) to  tasks/task_NNNNNN.bwd.h5.
+#
+# Because all state lives on the shared filesystem, the forward and backward passes can
+# run as different SLURM jobs (different nodes, different times, even different Julia
+# sessions / machines driving them), exactly like ordinary sweeps. This makes the outer
+# loop of an adjoint-based inverse design (value on the forward pass, gradient on the
+# backward pass) deployable to the cluster.
+#
+# Cotangent convention. `solve_k`'s pullback is exact for `k̄mags` cotangents (the usual
+# case: objectives built from neff = kmag/ω, ng, GVD, … are functions of `kmag`), giving
+# ∂/∂ω and ∂/∂ε⁻¹. `ēvecs` cotangents are phase-sensitive (they must match the exact
+# eigenvector phase of the forward solve); they are supported here by persisting and
+# reusing the forward eigenvectors, but objectives that depend on the field are usually
+# better expressed through the field post-processing rules (`group_index`, …) whose
+# adjoints already reduce to ε⁻¹/∂ε_∂ω cotangents.
+
+# ---------------------------------------------------------------------------------
+# worker side
+# ---------------------------------------------------------------------------------
+
+function run_forward_task(batch::BatchInfo, i::Int)
+    t0 = time()
+    started = now()
+    p = batch.params[i]
+    base = _task_base(batch, i)
+    rm(base * ".done"; force=true)
+    rm(base * ".failed"; force=true)
+    try
+        nev = batch.manifest["nev"]::Int
+        save_fields = batch.manifest["save_fields"]::Bool
+        save_plots = get(batch.manifest, "save_plots", false)::Bool
+        mode_labels = get(batch.manifest, "mode_labels", true)::Bool
+        label_max_order = Int(get(batch.manifest, "label_max_order", 4))
+        solver_str = batch.manifest["solver"]::String
+        solver_kwargs = NamedTuple(Symbol(k) => v for (k, v) in batch.manifest["solver_kwargs"])
+
+        m = _load_setup(batch.dir)
+        prob = Base.invokelatest(getfield(m, :make_problem), p)
+        solver = Core.eval(m, Meta.parse(solver_str))
+
+        # forward AD pass uses the plain (linear) solve_k that the adjoint rrule covers
+        summary, fields, Es = Base.invokelatest(_solve_and_summarize, p, prob, solver, nev,
+            solver_kwargs, true, mode_labels, label_max_order; allow_kerr=false)
+        summary["task"] = i
+        summary["params"] = Dict(String(k) => v for (k, v) in pairs(p))
+        summary["kind"] = "forward"
+        merge!(summary, _task_meta(t0, started))
+
+        _write_forward_state(base * ".fwd.h5", prob, fields, solver_str, nev)
+        _atomic_write(base * ".json", JSON3.write(summary))
+        save_fields && _write_fields(base * ".h5", fields)
+        save_plots && _write_plots(batch, i, summary, Es, prob.grid)
+        _atomic_write(base * ".done", "")
+        return summary
+    catch err
+        msg = sprint(showerror, err, catch_backtrace())
+        _atomic_write(base * ".failed", msg)
+        rethrow()
+    end
+end
+
+function run_backward_task(batch::BatchInfo, i::Int)
+    t0 = time()
+    started = now()
+    base = _task_base(batch, i)
+    rm(base * ".done"; force=true)
+    rm(base * ".failed"; force=true)
+    try
+        fwd_dir = batch.manifest["forward_dir"]::String
+        fwd_base = joinpath(fwd_dir, "tasks", "task_" * _task_id_str(i))
+        st = _load_forward_state(fwd_base * ".fwd.h5")
+        ct = _load_cotangents(base * ".ct.h5", st.nev)
+
+        mod = Module(:SweepSolver)
+        Core.eval(mod, :(using MaxwellEigenmodes))
+        solver = Core.eval(mod, Meta.parse(st.solver))
+
+        ω_bar, ε⁻¹_bar = Base.invokelatest(_remote_pullback, st.ω, st.ε⁻¹, st.grid, solver,
+            st.nev, ct.k̄mags, ct.ēvecs)
+        _write_backward_state(base * ".bwd.h5", ω_bar, ε⁻¹_bar)
+
+        summary = Dict{String,Any}("task" => i, "kind" => "backward",
+            "omega_bar" => ω_bar, "eps_inv_bar_norm" => sqrt(sum(abs2, ε⁻¹_bar)),
+            "forward_dir" => fwd_dir)
+        merge!(summary, _task_meta(t0, started))
+        _atomic_write(base * ".json", JSON3.write(summary))
+        _atomic_write(base * ".done", "")
+        return summary
+    catch err
+        msg = sprint(showerror, err, catch_backtrace())
+        _atomic_write(base * ".failed", msg)
+        rethrow()
+    end
+end
+
+"run the `solve_k` adjoint `rrule` for the saved forward state and output cotangents"
+function _remote_pullback(ω, ε⁻¹, grid, solver, nev::Int, k̄mags, ēvecs)
+    _, pb = rrule(solve_k, ω, copy(ε⁻¹), grid, solver; nev)
+    Δk = Any[k̄mags === nothing || !isfinite(k̄mags[j]) ? ZeroTangent() : Float64(k̄mags[j]) for j in 1:nev]
+    Δev = ēvecs === nothing ? Any[ZeroTangent() for _ in 1:nev] : Any[ēvecs[j] for j in 1:nev]
+    res = pb((Δk, Δev))
+    return (Float64(res[2]), Array{Float64}(res[3]))    # (ω̄, ε̄⁻¹)
+end
+
+# ---- forward-state / cotangent / backward-state I/O on the shared filesystem ----
+
+function _write_forward_state(path, prob::NamedTuple, fields::NamedTuple, solver::String, nev::Int)
+    g = prob.grid
+    tmp = path * ".tmp"
+    h5open(tmp, "w") do f
+        f["omega"] = Float64(fields.ω)
+        f["nev"] = nev
+        f["solver"] = solver
+        f["eps_inv"] = Array{Float64}(real.(prob.ε⁻¹))
+        f["deps_dom"] = Array{Float64}(real.(prob.∂ε_∂ω))
+        f["kmags"] = collect(Float64.(fields.kmags))
+        evm = hcat(fields.evecs...)
+        f["evecs_re"] = real.(evm)
+        f["evecs_im"] = imag.(evm)
+        f["grid_Δ"] = ndims(g) == 2 ? [g.Δx, g.Δy] : [g.Δx, g.Δy, g.Δz]
+        f["grid_N"] = collect(size(g))
+    end
+    mv(tmp, path; force=true)
+    return path
+end
+
+function _grid_from(Δ, N)
+    return length(N) == 2 ? Grid(Float64(Δ[1]), Float64(Δ[2]), Int(N[1]), Int(N[2])) :
+           Grid(Float64(Δ[1]), Float64(Δ[2]), Float64(Δ[3]), Int(N[1]), Int(N[2]), Int(N[3]))
+end
+
+function _load_forward_state(path)
+    isfile(path) || error("forward state not found at $path (was the forward batch run?)")
+    return h5open(path, "r") do f
+        nev = Int(read(f, "nev"))
+        evm = read(f, "evecs_re") .+ im .* read(f, "evecs_im")
+        (; ω=read(f, "omega"), nev, solver=read(f, "solver"),
+            ε⁻¹=read(f, "eps_inv"), ∂ε_∂ω=read(f, "deps_dom"),
+            kmags=read(f, "kmags"), evecs=[evm[:, j] for j in 1:nev],
+            grid=_grid_from(read(f, "grid_Δ"), read(f, "grid_N")))
+    end
+end
+
+"write a per-task output-cotangent file `(k̄mags[, ēvecs])` for a backward batch"
+function _write_cotangents(path, ct, nev::Int)
+    kbar = hasproperty(ct, :k̄) && ct.k̄ !== nothing ? collect(Float64.(ct.k̄)) : fill(NaN, nev)
+    length(kbar) == nev || throw(ArgumentError("k̄ must have length nev=$nev, got $(length(kbar))"))
+    tmp = path * ".tmp"
+    h5open(tmp, "w") do f
+        f["kbar"] = kbar
+        if hasproperty(ct, :ēv) && ct.ēv !== nothing
+            evm = hcat(ct.ēv...)
+            f["evbar_re"] = real.(evm)
+            f["evbar_im"] = imag.(evm)
+        end
+    end
+    mv(tmp, path; force=true)
+    return path
+end
+
+function _load_cotangents(path, nev::Int)
+    isfile(path) || error("cotangent file not found at $path")
+    return h5open(path, "r") do f
+        kbar = haskey(f, "kbar") ? read(f, "kbar") : nothing
+        evbar = nothing
+        if haskey(f, "evbar_re")
+            evm = read(f, "evbar_re") .+ im .* read(f, "evbar_im")
+            evbar = [evm[:, j] for j in 1:nev]
+        end
+        (; k̄mags=kbar, ēvecs=evbar)
+    end
+end
+
+function _write_backward_state(path, ω_bar, ε⁻¹_bar)
+    tmp = path * ".tmp"
+    h5open(tmp, "w") do f
+        f["omega_bar"] = Float64(ω_bar)
+        f["eps_inv_bar"] = Array{Float64}(ε⁻¹_bar)
+    end
+    mv(tmp, path; force=true)
+    return path
+end
+
+# ---------------------------------------------------------------------------------
+# user side
+# ---------------------------------------------------------------------------------
+
+"cluster-side path of a batch directory (remote_dir in ssh mode, else the local dir)"
+_cluster_dir(b::BatchInfo) = let r = get(b.manifest, "remote_dir", "")
+    isempty(r) ? b.dir : r
+end
+
+"""
+    deploy_forward(setup_file, params; nev=1, solver=…, slurm=…, backend=…, blocking=false, kwargs...) -> BatchInfo
+
+Deploy an AD **forward pass**: one task per parameter set runs the (linear) `solve_k`
+and, besides the usual summary (and optional fields/PNGs), persists everything the
+adjoint needs — `(ω, ε⁻¹, ∂ε_∂ω, grid, kmags, evecs, solver)` — to the shared
+filesystem (`tasks/task_NNNNNN.fwd.h5`). Pair it with [`deploy_backward`](@ref).
+
+Accepts the same keywords as [`deploy_batch`](@ref) (`nev`, `solver`, `solver_kwargs`,
+`save_fields`, `save_plots`, `mode_labels`, `backend`, `slurm`, `name`, `dir`, `submit`,
+`blocking`). Retrieve the primal solution with [`forward_solution`](@ref).
+"""
+function deploy_forward(setup_file::AbstractString, params; name::AbstractString="ad_forward",
+    kwargs...)
+    return deploy_batch(setup_file, params; name, kind="forward", kwargs...)
+end
+
+"""
+    forward_solution(batch, i=1) -> (; ω, kmags, evecs, ε⁻¹, ∂ε_∂ω, grid)
+
+Load the persisted forward-pass state of task `i` of a forward batch (the primal
+solution plus the adjoint inputs). In ssh mode the `.fwd.h5` file is fetched first.
+"""
+function forward_solution(batch::BatchInfo, i::Int=1)
+    _maybe_fetch_markers!(batch; fields=true)
+    return _load_forward_state(_task_base(batch, i) * ".fwd.h5")
+end
+
+"""
+    deploy_backward(forward_batch, cotangents; name="ad_backward", slurm=…, backend=…, blocking=false, kwargs...) -> BatchInfo
+
+Deploy an AD **backward pass** for a completed (or running) `forward_batch`. `cotangents`
+is a vector with one entry per forward task — each a `NamedTuple` `(; k̄, ēv=nothing)`
+giving the output cotangents (`k̄` w.r.t. the per-band `kmags`, length `nev`; optional
+`ēv` w.r.t. the eigenvectors). Each backward task loads its forward state from the
+forward batch's (shared) directory, runs the `solve_k` adjoint, and writes the input
+cotangents `(ω̄, ε̄⁻¹)` to `tasks/task_NNNNNN.bwd.h5`. Retrieve them with
+[`gradient_result`](@ref).
+
+The backward batch reuses the forward `solver`/`nev`; `backend`, `slurm`, `name`, `dir`,
+`submit`, `blocking` behave as in [`deploy_batch`](@ref).
+"""
+function deploy_backward(forward_batch::BatchInfo, cotangents::AbstractVector;
+    name::AbstractString="ad_backward", dir::AbstractString="",
+    backend::Symbol=:slurm, slurm::SlurmConfig=SlurmConfig(), submit::Bool=true,
+    blocking::Bool=false)
+    nfwd = length(forward_batch)
+    length(cotangents) == nfwd || throw(ArgumentError(
+        "expected one cotangent per forward task ($nfwd), got $(length(cotangents))"))
+    nev = forward_batch.manifest["nev"]::Int
+    fwd_cluster_dir = _cluster_dir(forward_batch)
+
+    # placeholder setup.jl (the backward worker reads forward state, never make_problem)
+    setup = joinpath(tempdir(), "modesweeps_backward_setup.jl")
+    write(setup, "make_problem(p) = error(\"backward batches have no setup\")\n")
+
+    prepare = function (bw::BatchInfo)
+        bw.manifest["forward_dir"] = fwd_cluster_dir
+        _write_manifest(bw.dir, bw.manifest)
+        for (i, ct) in enumerate(cotangents)
+            _write_cotangents(_task_base(bw, i) * ".ct.h5", ct, nev)
+        end
+    end
+
+    return deploy_batch(setup, forward_batch.params; name, dir, nev,
+        solver=forward_batch.manifest["solver"]::String, backend, slurm, submit, blocking,
+        kind="backward", prepare)
+end
+
+"""
+    gradient_result(backward_batch, i=1) -> (; ω_bar, ε⁻¹_bar)
+
+Load the input cotangents `(ω̄, ε̄⁻¹)` produced by task `i` of a backward batch — the
+gradient of the differentiated objective w.r.t. the optical frequency and the
+inverse-dielectric field. In ssh mode the `.bwd.h5` file is fetched first.
+"""
+function gradient_result(batch::BatchInfo, i::Int=1)
+    _maybe_fetch_markers!(batch; fields=true)
+    path = _task_base(batch, i) * ".bwd.h5"
+    isfile(path) || error("no backward result for task $i at $path (has the backward " *
+                          "batch finished? in ssh mode, results are fetched automatically)")
+    return h5open(path, "r") do f
+        (; ω_bar=read(f, "omega_bar"), ε⁻¹_bar=read(f, "eps_inv_bar"))
+    end
+end
+
+"""
+    remote_value_and_gradient(setup_file, p, k̄; ēv=nothing, nev=1, name="ad", kwargs...) -> NamedTuple
+
+Blocking convenience that runs a remote forward pass and then a remote backward pass for
+a single parameter set `p`, returning `(; kmags, evecs, ω_bar, ε⁻¹_bar, forward, backward)`
+— the primal solution and the gradient of an objective whose cotangent w.r.t. the
+per-band `kmags` is `k̄` (length `nev`). Both passes run as SLURM (or `:local`) tasks
+that exchange data through the shared filesystem; this call blocks until each completes.
+
+`kwargs` (e.g. `solver`, `solver_kwargs`, `backend`, `slurm`, `dir`) are forwarded to
+the forward deployment; the backward pass reuses the forward solver and SLURM config.
+"""
+function remote_value_and_gradient(setup_file::AbstractString, p::NamedTuple, k̄;
+    ēv=nothing, nev::Int=1, name::AbstractString="ad", dir::AbstractString="",
+    backend::Symbol=:slurm, slurm::SlurmConfig=SlurmConfig(), kwargs...)
+    fdir = isempty(dir) ? "" : dir * "_fwd"
+    bdir = isempty(dir) ? "" : dir * "_bwd"
+    fwd = deploy_forward(setup_file, [p]; nev, name=name * "_fwd", dir=fdir,
+        backend, slurm, blocking=true, kwargs...)
+    sol = forward_solution(fwd, 1)
+    bw = deploy_backward(fwd, [(; k̄, ēv)]; name=name * "_bwd", dir=bdir,
+        backend, slurm, blocking=true)
+    g = gradient_result(bw, 1)
+    return (; sol.kmags, sol.evecs, g.ω_bar, g.ε⁻¹_bar, forward=fwd, backward=bw)
+end

--- a/lib/ModeSweeps/src/batch.jl
+++ b/lib/ModeSweeps/src/batch.jl
@@ -132,7 +132,15 @@ Keyword options:
 - `nev=1`: number of bands per task.
 - `save_fields=false`: when `true`, workers additionally store full mode-field data
   (eigenvectors and E-fields) per task in HDF5; when `false` only the lightweight
-  summary (effective & group index, GVD, effective area, polarization) is produced.
+  summary (effective & group index, GVD, effective area, polarization, mode label,
+  timing, host) is produced.
+- `save_plots=false`: when `true`, workers render one annotated PNG per band (false-
+  colour `|Eₓ|,|E_y|,|E_z|` panels topped with the per-band summary) into `tasks/` and
+  (in ssh mode) transfer them back. Works regardless of `save_fields`.
+- `mode_labels=true`: classify every mode by a Hermite–Gaussian fit (TE/TM polarization
+  + transverse order, e.g. `TE₀₀`); adds `label`/`mode_pol`/`mode_m`/`mode_n`/
+  `hg_rel_error`/`te_frac` to the summary. Set `false` to skip the (small) fit cost.
+- `label_max_order=4`: maximum Hermite–Gaussian order tried by the mode classifier.
 - `solver="KrylovKitEigsolve()"`: an expression string constructing the eigensolver on
   the worker (e.g. `"GPUSolver(Float32)"` for the CUDA backend).
 - `solver_kwargs=(;)`: keyword arguments forwarded to `solve_k` (e.g. `k_tol`).
@@ -143,11 +151,20 @@ Keyword options:
 - `slurm=SlurmConfig()`: SLURM/worker configuration (also supplies the worker `julia`
   and project for the `:local` backend).
 - `submit=true`: set `false` for a dry run (alias for `backend=:none`).
+- `blocking=false`: when `true`, the call blocks until every task has finished (or
+  failed), polling the batch markers, before returning — turning the otherwise
+  asynchronous deployment into a synchronous one (see also [`wait_batch`](@ref)).
+- `kind="solve"`: task kind (`"solve"`, `"forward"`, `"backward"`); see the AD helpers
+  [`deploy_forward`](@ref)/[`deploy_backward`](@ref). Most users leave this default.
+- `prepare`: optional `prepare(batch)` callback run after the batch directory is written
+  but before submission (used internally by the AD helpers to stage extra inputs).
 """
 function deploy_batch(setup_file::AbstractString, params; name::AbstractString="",
-    dir::AbstractString="", nev::Int=1, save_fields::Bool=false,
+    dir::AbstractString="", nev::Int=1, save_fields::Bool=false, save_plots::Bool=false,
+    mode_labels::Bool=true, label_max_order::Int=4,
     solver::AbstractString="KrylovKitEigsolve()", solver_kwargs::NamedTuple=(;),
-    backend::Symbol=:slurm, slurm::SlurmConfig=SlurmConfig(), submit::Bool=true)
+    backend::Symbol=:slurm, slurm::SlurmConfig=SlurmConfig(), submit::Bool=true,
+    blocking::Bool=false, kind::AbstractString="solve", prepare=nothing)
 
     params_v = _normalize_params(params)
     isempty(params_v) && throw(ArgumentError("empty parameter list"))
@@ -171,9 +188,13 @@ function deploy_batch(setup_file::AbstractString, params; name::AbstractString="
     manifest = Dict{String,Any}(
         "name" => name,
         "created" => string(now()),
+        "kind" => String(kind),
         "n_tasks" => length(params_v),
         "nev" => nev,
         "save_fields" => save_fields,
+        "save_plots" => save_plots,
+        "mode_labels" => mode_labels,
+        "label_max_order" => label_max_order,
         "solver" => String(solver),
         "solver_kwargs" => Dict(String(k) => v for (k, v) in pairs(solver_kwargs)),
         "backend" => String(backend),
@@ -188,6 +209,7 @@ function deploy_batch(setup_file::AbstractString, params; name::AbstractString="
     _write_manifest(dir, manifest)
 
     batch = BatchInfo(dir, manifest, params_v)
+    prepare === nothing || prepare(batch)   # stage extra inputs before submission
     if backend === :slurm
         _submit_slurm!(batch, slurm)
     elseif backend === :local
@@ -197,6 +219,7 @@ function deploy_batch(setup_file::AbstractString, params; name::AbstractString="
     else
         throw(ArgumentError("unknown backend :$backend (expected :slurm, :local or :none)"))
     end
+    blocking && backend !== :none && wait_batch(batch)
     return batch
 end
 
@@ -289,15 +312,18 @@ scalars are held fixed and passed through to every task.
     frequency_sweep("my_setup.jl"; ω = 0.55:0.005:0.75, w_top = [1.4, 1.7], T = 30.0,
                     nev = 2, backend = :slurm, slurm = SlurmConfig(time="0:30:00"))
 
-Deployment options (`nev`, `save_fields`, `solver`, `solver_kwargs`, `backend`,
-`slurm`, `name`, `dir`, `submit`) are split off automatically; all other keywords
-become sweep parameters.
+Deployment options (`nev`, `save_fields`, `save_plots`, `mode_labels`,
+`label_max_order`, `solver`, `solver_kwargs`, `backend`, `slurm`, `name`, `dir`,
+`submit`, `blocking`) are split off automatically; all other keywords become sweep
+parameters.
 """
 function frequency_sweep(setup_file::AbstractString; ω, name::AbstractString="freq_sweep",
-    dir::AbstractString="", nev::Int=1, save_fields::Bool=false,
+    dir::AbstractString="", nev::Int=1, save_fields::Bool=false, save_plots::Bool=false,
+    mode_labels::Bool=true, label_max_order::Int=4,
     solver::AbstractString="KrylovKitEigsolve()", solver_kwargs::NamedTuple=(;),
-    backend::Symbol=:slurm, slurm::SlurmConfig=SlurmConfig(), submit::Bool=true, params...)
+    backend::Symbol=:slurm, slurm::SlurmConfig=SlurmConfig(), submit::Bool=true,
+    blocking::Bool=false, params...)
     grid_params = param_grid(; ω=ω, params...)
-    return deploy_batch(setup_file, grid_params; name, dir, nev, save_fields, solver,
-        solver_kwargs, backend, slurm, submit)
+    return deploy_batch(setup_file, grid_params; name, dir, nev, save_fields, save_plots,
+        mode_labels, label_max_order, solver, solver_kwargs, backend, slurm, submit, blocking)
 end

--- a/lib/ModeSweeps/src/gather.jl
+++ b/lib/ModeSweeps/src/gather.jl
@@ -4,17 +4,27 @@
 
 const _SUMMARY_COLS = (:kmag, :neff, :ng, :gvd, :Aeff, :pol_x, :pol_y, :pol_z, :pol_axis)
 
+# safe typed accessors for JSON3 objects (older batches may lack the newer keys)
+_gs(o, k, d) = haskey(o, k) && o[k] !== nothing ? String(o[k]) : d
+_gf(o, k, d) = haskey(o, k) && o[k] !== nothing ? Float64(o[k]) : d
+_gi(o, k, d) = haskey(o, k) && o[k] !== nothing ? Int(o[k]) : d
+
 """
-    gather_batch(batch; partial=true, save=true, formats=(:csv,:tsv,:json), fetch_fields=false)
+    gather_batch(batch; partial=true, save=true, formats=(:csv,:tsv,:json),
+                 fetch_fields=false, fetch_plots=true)
 
 Collect the results of a deployed batch into a flat summary table: a
 `Vector{NamedTuple}` (a Tables.jl row table — pass it to `DataFrame`, `CSV.write`, …)
 with one row per task × band, containing the swept parameters, `task`, `band`,
-`status`, and the summary quantities `kmag`, `neff` (effective index), `ng` (group
-index), `gvd`, `Aeff` (effective area) and the polarization fractions
-`pol_x`/`pol_y`/`pol_z` (+ dominant `pol_axis`), plus the Kerr columns `dneff_kerr`
-(power-dependent effective-index shift) and `dn_max` (peak index perturbation) for
-power-corrected solves (zero for linear solves).
+`status`, and the summary quantities:
+
+- `kmag`, `neff` (effective index), `ng` (group index), `gvd`, `Aeff` (effective area),
+  the polarization fractions `pol_x`/`pol_y`/`pol_z` (+ dominant `pol_axis`);
+- the mode-character columns `label` (e.g. `"TE₀₀"`), `mode_pol` (`"TE"`/`"TM"`),
+  `mode_m`/`mode_n` (transverse orders), `hg_rel_error` (fit goodness) and `te_frac`;
+- the Kerr columns `dneff_kerr` and `dn_max` (zero for linear solves);
+- the execution metadata `host`/`runtime_s`/`started`/`finished` and the SLURM
+  `slurm_job`/`slurm_task` ids (all computed on the worker).
 
 - `partial=true`: gather whatever is finished so far (works while the batch is still
   running); rows for unfinished tasks are omitted and failed tasks get a row per band
@@ -24,13 +34,15 @@ power-corrected solves (zero for linear solves).
   `formats` (supported: `:csv`, `:tsv`, `:json`); reload with [`load_summary`](@ref).
 - `fetch_fields=true`: in ssh mode, also transfer the (large) per-task HDF5 field
   files from the cluster, not just the summaries.
+- `fetch_plots=true`: in ssh mode, also transfer the per-band PNG images (small).
 
 Use [`load_fields`](@ref)`(batch, i)` for the full mode-field data of one task
-(batches deployed with `save_fields=true`).
+(batches deployed with `save_fields=true`) and [`plot_paths`](@ref)`(batch, i)` for the
+annotated PNGs (batches deployed with `save_plots=true`).
 """
 function gather_batch(batch::BatchInfo; partial::Bool=true, save::Bool=true,
-    formats=(:csv, :tsv, :json), fetch_fields::Bool=false)
-    _maybe_fetch_markers!(batch; fields=fetch_fields)
+    formats=(:csv, :tsv, :json), fetch_fields::Bool=false, fetch_plots::Bool=true)
+    _maybe_fetch_markers!(batch; fields=fetch_fields, plots=fetch_plots)
     st = batch_status(batch; verbose=false)
     if !partial && (st.done < st.total)
         error("batch incomplete ($(st.done)/$(st.total) done, $(st.failed) failed); " *
@@ -44,6 +56,10 @@ function gather_batch(batch::BatchInfo; partial::Bool=true, save::Bool=true,
         pvals = NamedTuple{pkeys}(Tuple(batch.params[i][k] for k in pkeys))
         if isfile(base * ".done") && isfile(base * ".json")
             summary = JSON3.read(read(base * ".json", String))
+            meta = (; host=_gs(summary, :node, _gs(summary, :host, "")),
+                runtime_s=_gf(summary, :runtime_s, NaN),
+                started=_gs(summary, :started, ""), finished=_gs(summary, :finished, ""),
+                slurm_job=_gs(summary, :slurm_job, ""), slurm_task=_gs(summary, :slurm_task, ""))
             for bd in summary.bands
                 push!(rows, merge((; task=i), pvals, (;
                     band=Int(bd.band), status="done",
@@ -51,9 +67,11 @@ function gather_batch(batch::BatchInfo; partial::Bool=true, save::Bool=true,
                     gvd=Float64(bd.gvd), Aeff=Float64(bd.Aeff),
                     pol_x=Float64(bd.pol_x), pol_y=Float64(bd.pol_y), pol_z=Float64(bd.pol_z),
                     pol_axis=Int(bd.pol_axis),
-                    dneff_kerr=haskey(bd, :dneff_kerr) ? Float64(bd.dneff_kerr) : 0.0,
-                    dn_max=haskey(bd, :dn_max) ? Float64(bd.dn_max) : 0.0,
-                )))
+                    label=_gs(bd, :label, ""), mode_pol=_gs(bd, :mode_pol, ""),
+                    mode_m=_gi(bd, :mode_m, 0), mode_n=_gi(bd, :mode_n, 0),
+                    hg_rel_error=_gf(bd, :hg_rel_error, NaN), te_frac=_gf(bd, :te_frac, NaN),
+                    dneff_kerr=_gf(bd, :dneff_kerr, 0.0), dn_max=_gf(bd, :dn_max, 0.0)),
+                    meta))
             end
         elseif isfile(base * ".failed")
             for b in 1:nev
@@ -61,8 +79,11 @@ function gather_batch(batch::BatchInfo; partial::Bool=true, save::Bool=true,
                     band=b, status="failed",
                     kmag=NaN, neff=NaN, ng=NaN, gvd=NaN, Aeff=NaN,
                     pol_x=NaN, pol_y=NaN, pol_z=NaN, pol_axis=0,
+                    label="", mode_pol="", mode_m=0, mode_n=0,
+                    hg_rel_error=NaN, te_frac=NaN,
                     dneff_kerr=NaN, dn_max=NaN,
-                )))
+                    host="", runtime_s=NaN, started="", finished="",
+                    slurm_job="", slurm_task="")))
             end
         end
     end
@@ -70,6 +91,23 @@ function gather_batch(batch::BatchInfo; partial::Bool=true, save::Bool=true,
         save_summary(rows, joinpath(batch.dir, "summary"); formats)
     end
     return rows
+end
+
+"""
+    plot_paths(batch, i) -> Vector{String}
+
+Paths of the annotated mode-field PNGs for task `i` (one per band), for batches deployed
+with `save_plots=true`. Returns only files that exist (in ssh mode, fetch them first
+with `gather_batch(batch; fetch_plots=true)`).
+"""
+function plot_paths(batch::BatchInfo, i::Int)
+    base = _task_base(batch, i)
+    paths = String[]
+    for b in 1:batch.manifest["nev"]::Int
+        p = base * "_b" * @sprintf("%02i", b) * ".png"
+        isfile(p) && push!(paths, p)
+    end
+    return paths
 end
 
 """

--- a/lib/ModeSweeps/src/render.jl
+++ b/lib/ModeSweeps/src/render.jl
@@ -1,0 +1,307 @@
+# Self-contained mode-field image rendering.
+#
+# Workers save one annotated PNG per band (false-colour |Eₓ|,|E_y|,|E_z| panels plus a
+# text header carrying the per-band summary). The renderer is deliberately
+# dependency-free — a small pure-Julia PNG encoder (uncompressed DEFLATE blocks, so no
+# zlib needed), a viridis-like colormap, and a compact 5×7 bitmap font — so that PNGs
+# are produced on any SLURM worker without a plotting stack or display, and the feature
+# works identically for `save_fields=true` (full) and summary-only batches.
+#
+# For publication-quality figures, load the full field data (`load_fields`) into a
+# Makie/Plots session locally; these PNGs are for quick at-a-glance inspection of a
+# whole sweep alongside the tabular summary.
+
+# ---------------------------------------------------------------------------------
+# checksums (CRC-32 / Adler-32) and the minimal PNG container
+# ---------------------------------------------------------------------------------
+
+const _CRC32_TABLE = let tbl = Vector{UInt32}(undef, 256)
+    for n in 0:255
+        c = UInt32(n)
+        for _ in 1:8
+            c = (c & 0x00000001) != 0 ? (0xedb88320 ⊻ (c >> 1)) : (c >> 1)
+        end
+        tbl[n+1] = c
+    end
+    tbl
+end
+
+function _crc32(data::AbstractVector{UInt8}, crc::UInt32=0xffffffff)
+    @inbounds for b in data
+        crc = _CRC32_TABLE[((crc ⊻ b) & 0xff)+1] ⊻ (crc >> 8)
+    end
+    return crc
+end
+_crc32_final(data::AbstractVector{UInt8}) = _crc32(data) ⊻ 0xffffffff
+
+function _adler32(data::AbstractVector{UInt8})
+    a = UInt32(1)
+    b = UInt32(0)
+    @inbounds for byte in data
+        a = (a + byte) % 0xfff1
+        b = (b + a) % 0xfff1
+    end
+    return (b << 16) | a
+end
+
+_be(x::UInt32) = UInt8[(x>>24)&0xff, (x>>16)&0xff, (x>>8)&0xff, x&0xff]
+_le16(x::Integer) = UInt8[x&0xff, (x>>8)&0xff]
+
+function _png_chunk(io::IO, typ::String, data::AbstractVector{UInt8})
+    write(io, _be(UInt32(length(data))))
+    tb = Vector{UInt8}(codeunits(typ))
+    write(io, tb)
+    write(io, data)
+    write(io, _be(_crc32_final(vcat(tb, data))))
+    return nothing
+end
+
+"zlib stream wrapping `raw` in uncompressed (stored) DEFLATE blocks — no zlib dependency"
+function _zlib_stored(raw::AbstractVector{UInt8})
+    out = UInt8[0x78, 0x01]                 # zlib header (CM=8, no preset dict, fastest)
+    n = length(raw)
+    pos = 1
+    while pos <= n || n == 0
+        chunk = min(n - pos + 1, 65535)
+        final = (pos + chunk - 1) >= n
+        push!(out, final ? 0x01 : 0x00)     # BFINAL bit + BTYPE=00 (stored)
+        append!(out, _le16(chunk))
+        append!(out, _le16(0xffff ⊻ chunk)) # NLEN = ~LEN
+        chunk > 0 && append!(out, @view raw[pos:pos+chunk-1])
+        pos += chunk
+        (final || n == 0) && break
+    end
+    append!(out, _be(_adler32(raw)))
+    return out
+end
+
+"""
+    write_png(path, canvas)
+
+Encode an `(H, W, 3)` `UInt8` RGB array to a PNG file at `path` using a dependency-free
+encoder (stored DEFLATE blocks). Returns `path`.
+"""
+function write_png(path::AbstractString, canvas::AbstractArray{UInt8,3})
+    H, W, C = size(canvas)
+    C == 3 || throw(ArgumentError("canvas must be (H,W,3) RGB, got $(size(canvas))"))
+    # raw scanlines: each row prefixed with filter byte 0 (none)
+    raw = Vector{UInt8}(undef, H * (1 + 3W))
+    o = 1
+    @inbounds for r in 1:H
+        raw[o] = 0x00; o += 1
+        for c in 1:W, ch in 1:3
+            raw[o] = canvas[r, c, ch]; o += 1
+        end
+    end
+    tmp = path * ".tmp"
+    open(tmp, "w") do io
+        write(io, UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])  # PNG signature
+        ihdr = vcat(_be(UInt32(W)), _be(UInt32(H)), UInt8[8, 2, 0, 0, 0]) # 8-bit truecolor
+        _png_chunk(io, "IHDR", ihdr)
+        _png_chunk(io, "IDAT", _zlib_stored(raw))
+        _png_chunk(io, "IEND", UInt8[])
+    end
+    mv(tmp, path; force=true)
+    return path
+end
+
+# ---------------------------------------------------------------------------------
+# colormap
+# ---------------------------------------------------------------------------------
+
+const _VIRIDIS = (
+    (68, 1, 84), (72, 40, 120), (62, 74, 137), (49, 104, 142), (38, 130, 142),
+    (31, 158, 137), (53, 183, 121), (110, 206, 88), (181, 222, 43), (253, 231, 37),
+)
+
+"map t∈[0,1] to an RGB `NTuple{3,UInt8}` on a viridis-like ramp"
+function _colormap(t::Real)
+    t = isfinite(t) ? clamp(float(t), 0.0, 1.0) : 0.0
+    s = t * (length(_VIRIDIS) - 1)
+    i = floor(Int, s)
+    i >= length(_VIRIDIS) - 1 && return map(UInt8, _VIRIDIS[end])
+    f = s - i
+    a = _VIRIDIS[i+1]
+    b = _VIRIDIS[i+2]
+    return ntuple(j -> round(UInt8, a[j] + f * (b[j] - a[j])), 3)
+end
+
+# ---------------------------------------------------------------------------------
+# 5×7 bitmap font (string-art so glyphs are verifiable by eye); text is upper-cased
+# before rendering, so only digits, A–Z, space and a handful of symbols are needed.
+# ---------------------------------------------------------------------------------
+
+const _FONT_ART = Dict{Char,Vector{String}}(
+    ' ' => ["     ", "     ", "     ", "     ", "     ", "     ", "     "],
+    '0' => [".###.", "#...#", "#..##", "#.#.#", "##..#", "#...#", ".###."],
+    '1' => ["..#..", ".##..", "..#..", "..#..", "..#..", "..#..", ".###."],
+    '2' => [".###.", "#...#", "....#", "...#.", "..#..", ".#...", "#####"],
+    '3' => ["#####", "...#.", "..#..", "...#.", "....#", "#...#", ".###."],
+    '4' => ["...#.", "..##.", ".#.#.", "#..#.", "#####", "...#.", "...#."],
+    '5' => ["#####", "#....", "####.", "....#", "....#", "#...#", ".###."],
+    '6' => ["..##.", ".#...", "#....", "####.", "#...#", "#...#", ".###."],
+    '7' => ["#####", "....#", "...#.", "..#..", ".#...", ".#...", ".#..."],
+    '8' => [".###.", "#...#", "#...#", ".###.", "#...#", "#...#", ".###."],
+    '9' => [".###.", "#...#", "#...#", ".####", "....#", "...#.", ".##.."],
+    'A' => [".###.", "#...#", "#...#", "#####", "#...#", "#...#", "#...#"],
+    'B' => ["####.", "#...#", "#...#", "####.", "#...#", "#...#", "####."],
+    'C' => [".###.", "#...#", "#....", "#....", "#....", "#...#", ".###."],
+    'D' => ["###..", "#..#.", "#...#", "#...#", "#...#", "#..#.", "###.."],
+    'E' => ["#####", "#....", "#....", "####.", "#....", "#....", "#####"],
+    'F' => ["#####", "#....", "#....", "####.", "#....", "#....", "#...."],
+    'G' => [".###.", "#...#", "#....", "#.###", "#...#", "#...#", ".###."],
+    'H' => ["#...#", "#...#", "#...#", "#####", "#...#", "#...#", "#...#"],
+    'I' => [".###.", "..#..", "..#..", "..#..", "..#..", "..#..", ".###."],
+    'J' => ["..###", "...#.", "...#.", "...#.", "#..#.", "#..#.", ".##.."],
+    'K' => ["#...#", "#..#.", "#.#..", "##...", "#.#..", "#..#.", "#...#"],
+    'L' => ["#....", "#....", "#....", "#....", "#....", "#....", "#####"],
+    'M' => ["#...#", "##.##", "#.#.#", "#.#.#", "#...#", "#...#", "#...#"],
+    'N' => ["#...#", "##..#", "#.#.#", "#.#.#", "#..##", "#...#", "#...#"],
+    'O' => [".###.", "#...#", "#...#", "#...#", "#...#", "#...#", ".###."],
+    'P' => ["####.", "#...#", "#...#", "####.", "#....", "#....", "#...."],
+    'Q' => [".###.", "#...#", "#...#", "#...#", "#.#.#", "#..#.", ".##.#"],
+    'R' => ["####.", "#...#", "#...#", "####.", "#.#..", "#..#.", "#...#"],
+    'S' => [".####", "#....", "#....", ".###.", "....#", "....#", "####."],
+    'T' => ["#####", "..#..", "..#..", "..#..", "..#..", "..#..", "..#.."],
+    'U' => ["#...#", "#...#", "#...#", "#...#", "#...#", "#...#", ".###."],
+    'V' => ["#...#", "#...#", "#...#", "#...#", "#...#", ".#.#.", "..#.."],
+    'W' => ["#...#", "#...#", "#...#", "#.#.#", "#.#.#", "##.##", "#...#"],
+    'X' => ["#...#", "#...#", ".#.#.", "..#..", ".#.#.", "#...#", "#...#"],
+    'Y' => ["#...#", "#...#", ".#.#.", "..#..", "..#..", "..#..", "..#.."],
+    'Z' => ["#####", "....#", "...#.", "..#..", ".#...", "#....", "#####"],
+    '.' => ["     ", "     ", "     ", "     ", "     ", "..#..", "..#.."],
+    ',' => ["     ", "     ", "     ", "     ", "..#..", "..#..", ".#..."],
+    ':' => ["     ", "..#..", "..#..", "     ", "..#..", "..#..", "     "],
+    '-' => ["     ", "     ", "     ", "#####", "     ", "     ", "     "],
+    '+' => ["     ", "..#..", "..#..", "#####", "..#..", "..#..", "     "],
+    '=' => ["     ", "     ", "#####", "     ", "#####", "     ", "     "],
+    '/' => ["....#", "....#", "...#.", "..#..", ".#...", "#....", "#...."],
+    '(' => ["..#..", ".#...", "#....", "#....", "#....", ".#...", "..#.."],
+    ')' => ["..#..", "...#.", "....#", "....#", "....#", "...#.", "..#.."],
+    '%' => ["##..#", "##.#.", "..#..", ".#.##", "#..##", "     ", "     "],
+    '|' => ["..#..", "..#..", "..#..", "..#..", "..#..", "..#..", "..#.."],
+    '<' => ["...#.", "..#..", ".#...", "#....", ".#...", "..#..", "...#."],
+    '>' => [".#...", "..#..", "...#.", "....#", "...#.", "..#..", ".#..."],
+    '#' => [".#.#.", ".#.#.", "#####", ".#.#.", "#####", ".#.#.", ".#.#."],
+)
+
+# parsed once into (col-bit) masks: glyph[row] has bit (5-c) set for a lit pixel.
+# Byte-indexed and bounds-safe (the art is ASCII) so a short/long row can never error.
+_lit(s::AbstractString, c::Int) = c <= ncodeunits(s) && codeunit(s, c) != UInt8(' ')
+_row_mask(s::AbstractString) = reduce(|, (_lit(s, c) ? (UInt8(1) << (5 - c)) : UInt8(0) for c in 1:5); init=UInt8(0))
+const _FONT = Dict{Char,NTuple{7,UInt8}}(
+    ch => ntuple(r -> r <= length(art) ? _row_mask(art[r]) : UInt8(0), 7)
+    for (ch, art) in _FONT_ART
+)
+
+const _GLYPH_W = 5
+const _GLYPH_H = 7
+
+"draw upper-cased ASCII `str` into `canvas` with top-left at (row,col); `scale` enlarges pixels"
+function draw_text!(canvas::AbstractArray{UInt8,3}, row::Int, col::Int, str::AbstractString,
+    color::NTuple{3,UInt8}=(20, 20, 20); scale::Int=1, spacing::Int=1)
+    H, W, _ = size(canvas)
+    cx = col
+    for ch in uppercase(str)
+        glyph = get(_FONT, ch, _FONT[' '])
+        for gr in 1:_GLYPH_H, gc in 1:_GLYPH_W
+            if (glyph[gr] & (UInt8(1) << (5 - gc))) != 0
+                for sr in 0:scale-1, sc in 0:scale-1
+                    pr = row + (gr - 1) * scale + sr
+                    pc = cx + (gc - 1) * scale + sc
+                    if 1 <= pr <= H && 1 <= pc <= W
+                        canvas[pr, pc, 1] = color[1]
+                        canvas[pr, pc, 2] = color[2]
+                        canvas[pr, pc, 3] = color[3]
+                    end
+                end
+            end
+        end
+        cx += (_GLYPH_W + spacing) * scale
+    end
+    return canvas
+end
+
+text_width(str::AbstractString; scale::Int=1, spacing::Int=1) =
+    length(str) * (_GLYPH_W + spacing) * scale
+
+# ---------------------------------------------------------------------------------
+# field panels and the composite mode image
+# ---------------------------------------------------------------------------------
+
+"colour a real `(Nx,Ny)` field `F` into `canvas` at (row0,col0), upscaled by `scale`,
+normalized to `vmax` (its own max if `nothing`); returns the drawn (height,width)."
+function blit_field!(canvas::AbstractArray{UInt8,3}, row0::Int, col0::Int,
+    F::AbstractMatrix{<:Real}, scale::Int; vmax=nothing)
+    Nx, Ny = size(F)
+    mx = vmax === nothing ? maximum(F) : vmax
+    mx = mx > 0 ? mx : 1.0
+    H, W, _ = size(canvas)
+    # image rows = +y at top: row r ↔ iy = Ny - r + 1; image cols = +x: col c ↔ ix
+    for r in 1:Ny, c in 1:Nx
+        iy = Ny - r + 1
+        rgb = _colormap(F[c, iy] / mx)
+        for sr in 0:scale-1, sc in 0:scale-1
+            pr = row0 + (r - 1) * scale + sr
+            pc = col0 + (c - 1) * scale + sc
+            if 1 <= pr <= H && 1 <= pc <= W
+                canvas[pr, pc, 1] = rgb[1]
+                canvas[pr, pc, 2] = rgb[2]
+                canvas[pr, pc, 3] = rgb[3]
+            end
+        end
+    end
+    return (Ny * scale, Nx * scale)
+end
+
+"choose an integer upscale so the field panels are at least ~`target` px in their larger dim"
+function _panel_scale(Nx::Int, Ny::Int; target::Int=160, maxscale::Int=12)
+    d = max(Nx, Ny)
+    d <= 0 && return 1
+    return clamp(cld(target, d), 1, maxscale)
+end
+
+"""
+    render_mode_png(path, E, grid, header, titles=("|Ex|","|Ey|","|Ez|"); scale=auto)
+
+Render a composite PNG for one mode: a row of viridis-coloured `|Eₓ|`, `|E_y|`, `|E_z|`
+panels (each normalized to the field's global maximum so relative component strengths
+are visible) topped by a white header carrying the `header` text lines (the per-band
+summary). `E` is the `(3, Nx, Ny)` complex field from `E⃗`. Returns `path`.
+"""
+function render_mode_png(path::AbstractString, E::AbstractArray{<:Complex,3}, grid,
+    header::AbstractVector{<:AbstractString},
+    titles=("|EX|", "|EY|", "|EZ|"); scale::Union{Nothing,Int}=nothing)
+    _, Nx, Ny = size(E)
+    sc = scale === nothing ? _panel_scale(Nx, Ny) : scale
+    pw, ph = Nx * sc, Ny * sc
+
+    pad = 8
+    title_h = _GLYPH_H + 4
+    line_h = _GLYPH_H + 3
+    header_h = pad + length(header) * line_h + pad
+    panels_w = 3 * pw + 4 * pad
+    Wtot = max(panels_w, pad + maximum(text_width.(header); init=0) + pad)
+    Htot = header_h + title_h + ph + pad
+
+    canvas = fill(UInt8(255), Htot, Wtot, 3)   # white background
+
+    # header text (dark grey)
+    for (i, line) in enumerate(header)
+        draw_text!(canvas, pad + (i - 1) * line_h, pad, line, (25, 25, 30); scale=1)
+    end
+    # separator
+    sepr = header_h - 1
+    for c in 1:Wtot, ch in 1:3
+        canvas[clamp(sepr, 1, Htot), c, ch] = 0xc0
+    end
+
+    mags = (abs.(view(E, 1, :, :)), abs.(view(E, 2, :, :)), abs.(view(E, 3, :, :)))
+    gmax = maximum(maximum.(mags))
+    for (j, F) in enumerate(mags)
+        col0 = pad + (j - 1) * (pw + pad)
+        draw_text!(canvas, header_h + 2, col0, titles[j], (40, 40, 40); scale=1)
+        blit_field!(canvas, header_h + title_h, col0, F, sc; vmax=gmax)
+    end
+    return write_png(path, canvas)
+end

--- a/lib/ModeSweeps/src/status.jl
+++ b/lib/ModeSweeps/src/status.jl
@@ -39,13 +39,14 @@ function batch_status(batch::BatchInfo; verbose::Bool=true)
 end
 
 "fetch per-task summaries & markers from the remote cluster (ssh mode only)"
-function _maybe_fetch_markers!(batch::BatchInfo; fields::Bool=false)
+function _maybe_fetch_markers!(batch::BatchInfo; fields::Bool=false, plots::Bool=true)
     ssh = get(batch.manifest, "ssh", "")
     isempty(ssh) && return nothing
     remote = get(batch.manifest, "remote_dir", "")
     isempty(remote) && return nothing
     incl = ["--include=*.json", "--include=*.done", "--include=*.failed"]
-    fields && push!(incl, "--include=*.h5")
+    plots && push!(incl, "--include=*.png")     # annotated mode-field images (small)
+    fields && push!(incl, "--include=*.h5")     # full field data (large; on demand)
     cmd = Cmd(vcat(["rsync", "-a"], incl,
         ["--exclude=*", "$ssh:$remote/tasks/", joinpath(batch.dir, "tasks") * "/"]))
     try
@@ -54,6 +55,33 @@ function _maybe_fetch_markers!(batch::BatchInfo; fields::Bool=false)
         @warn "could not sync task results from $ssh:$remote" exception = err
     end
     return nothing
+end
+
+"""
+    wait_batch(batch; timeout=Inf, poll=10, verbose=true) -> NamedTuple
+
+Block until every task of `batch` has finished (`done` + `failed` == `total`) or
+`timeout` seconds elapse, polling the batch markers every `poll` seconds (in ssh mode
+each poll first rsyncs the markers from the cluster). Returns the final
+[`batch_status`](@ref). This is the synchronous counterpart to the otherwise
+asynchronous [`deploy_batch`](@ref); `deploy_batch(...; blocking=true)` calls it for you.
+
+Works from any Julia session at any time — e.g. reconnect to a long-running batch with
+`wait_batch(load_batch(dir))`.
+"""
+function wait_batch(batch::BatchInfo; timeout::Real=Inf, poll::Real=10, verbose::Bool=true)
+    t0 = time()
+    st = batch_status(batch; verbose=false)
+    while st.pending > 0 && (time() - t0) < timeout
+        sleep(poll)
+        st = batch_status(batch; verbose=false)
+    end
+    if verbose
+        msg = st.pending > 0 ? "timed out" : "complete"
+        @info "wait_batch: batch \"$(get(batch.manifest, "name", "?"))\" $msg — " *
+              "$(st.done)/$(st.total) done, $(st.failed) failed, $(st.pending) pending"
+    end
+    return st
 end
 
 "squeue lines for the batch's array job, or `nothing` when not applicable/available"

--- a/lib/ModeSweeps/src/worker.jl
+++ b/lib/ModeSweeps/src/worker.jl
@@ -1,22 +1,68 @@
-# Worker side: `run_task(batchdir, i)` executes one parameter set of a deployed batch.
-# Invoked by the generated `runtask.jl` inside each SLURM array task (or local process).
+# Worker side: `run_task(batchdir, i)` executes one task of a deployed batch. Invoked by
+# the generated `runtask.jl` inside each SLURM array task (or local process).
 #
-# Per task it writes, atomically:
-#   tasks/task_NNNNNN.json   per-band summary (neff, ng, GVD, effective area, polarization)
-#   tasks/task_NNNNNN.h5     full mode-field data (only when the batch was deployed
-#                            with save_fields=true)
-#   tasks/task_NNNNNN.done   completion marker (or .failed with the error text)
+# A batch has a `kind`:
+#   "solve"    (default) — solve for the requested bands of one parameter set and write
+#                          the per-band summary (+ optional fields / PNGs).
+#   "forward"  — AD forward pass: solve and additionally persist everything the adjoint
+#                needs (ε⁻¹, ∂ε_∂ω, the converged k & eigenvectors) to the shared
+#                filesystem, for a later `"backward"` task (see adjoint.jl).
+#   "backward" — AD backward pass: load a forward task's saved state plus output
+#                cotangents and run the `solve_k` adjoint, writing the input cotangents.
+#
+# Per "solve"/"forward" task it writes, atomically:
+#   tasks/task_NNNNNN.json     per-band summary (neff, ng, GVD, Aeff, polarization, mode
+#                              label, timing, host, …)
+#   tasks/task_NNNNNN.h5       full mode-field data (only when save_fields=true)
+#   tasks/task_NNNNNN_bMM.png  annotated mode-field image per band (when save_plots=true)
+#   tasks/task_NNNNNN.done     completion marker (or .failed with the error text)
 
 """
     run_task(batchdir, i::Int)
 
-Run task `i` (1-based) of the batch deployed in `batchdir`: build the problem via the
-batch's `setup.jl` (`make_problem(p)`), solve for the requested bands, compute the
-per-band summary quantities, and write results into `batchdir/tasks/`.
+Run task `i` (1-based) of the batch deployed in `batchdir`. Dispatches on the batch
+`kind` (`"solve"`, `"forward"`, `"backward"`); for the default solve, it builds the
+problem via the batch's `setup.jl` (`make_problem(p)`), solves the requested bands,
+computes the per-band summary quantities (and optional fields/PNGs), and writes results
+into `batchdir/tasks/`.
 """
 function run_task(batchdir::AbstractString, i::Int)
-    t0 = time()
     batch = load_batch(batchdir)
+    kind = get(batch.manifest, "kind", "solve")
+    if kind == "forward"
+        return run_forward_task(batch, i)
+    elseif kind == "backward"
+        return run_backward_task(batch, i)
+    else
+        return _run_solve_task(batch, i)
+    end
+end
+
+"per-task execution metadata (timing + scheduler/host identity)"
+function _task_meta(t0::Float64, started::DateTime)
+    return Dict{String,Any}(
+        "host" => gethostname(),
+        "node" => get(ENV, "SLURMD_NODENAME", gethostname()),
+        "slurm_job" => get(ENV, "SLURM_ARRAY_JOB_ID", get(ENV, "SLURM_JOB_ID", "")),
+        "slurm_task" => get(ENV, "SLURM_ARRAY_TASK_ID", ""),
+        "started" => string(started),
+        "finished" => string(now()),
+        "runtime_s" => round(time() - t0; digits=3),
+    )
+end
+
+"load `make_problem` from the batch's setup.jl inside a fresh module with the stack loaded"
+function _load_setup(batchdir::AbstractString)
+    m = Module(:SweepSetup)
+    Core.eval(m, :(using ModeSweeps, MaterialDispersion, DielectricSmoothing,
+        MaxwellEigenmodes, ModeAnalysis, LinearAlgebra))
+    Base.include(m, joinpath(batchdir, "setup.jl"))
+    return m
+end
+
+function _run_solve_task(batch::BatchInfo, i::Int)
+    t0 = time()
+    started = now()
     p = batch.params[i]
     base = _task_base(batch, i)
     rm(base * ".done"; force=true)
@@ -24,24 +70,25 @@ function run_task(batchdir::AbstractString, i::Int)
     try
         nev = batch.manifest["nev"]::Int
         save_fields = batch.manifest["save_fields"]::Bool
+        save_plots = get(batch.manifest, "save_plots", false)::Bool
+        mode_labels = get(batch.manifest, "mode_labels", true)::Bool
+        label_max_order = get(batch.manifest, "label_max_order", 4)
         solver_kwargs = NamedTuple(Symbol(k) => v for (k, v) in batch.manifest["solver_kwargs"])
 
-        # build the problem & solver inside a fresh module with the stack pre-loaded
-        m = Module(:SweepSetup)
-        Core.eval(m, :(using ModeSweeps, MaterialDispersion, DielectricSmoothing,
-            MaxwellEigenmodes, ModeAnalysis, LinearAlgebra))
-        Base.include(m, joinpath(batchdir, "setup.jl"))
+        m = _load_setup(batch.dir)
         prob = Base.invokelatest(getfield(m, :make_problem), p)
         solver = Core.eval(m, Meta.parse(batch.manifest["solver"]::String))
 
-        summary, fields = Base.invokelatest(_solve_and_summarize, p, prob, solver, nev, solver_kwargs, save_fields)
+        need_E = save_fields || save_plots
+        summary, fields, Es = Base.invokelatest(_solve_and_summarize, p, prob, solver, nev,
+            solver_kwargs, need_E, mode_labels, Int(label_max_order))
         summary["task"] = i
         summary["params"] = Dict(String(k) => v for (k, v) in pairs(p))
-        summary["runtime_s"] = round(time() - t0; digits=3)
-        summary["finished"] = string(now())
+        merge!(summary, _task_meta(t0, started))
 
         _atomic_write(base * ".json", JSON3.write(summary))
         save_fields && _write_fields(base * ".h5", fields)
+        save_plots && _write_plots(batch, i, summary, Es, prob.grid)
         _atomic_write(base * ".done", "")
         return summary
     catch err
@@ -58,9 +105,10 @@ function _atomic_write(path::AbstractString, content::AbstractString)
     return path
 end
 
-"solve one parameter set and compute per-band summary quantities (+ optional field data)"
+"solve one parameter set and compute per-band summary quantities (+ optional E fields)"
 function _solve_and_summarize(p::NamedTuple, prob::NamedTuple, solver, nev::Int,
-    solver_kwargs::NamedTuple, save_fields::Bool)
+    solver_kwargs::NamedTuple, need_E::Bool, mode_labels::Bool, label_max_order::Int;
+    allow_kerr::Bool=true)
     haskey(p, :ω) || throw(ArgumentError("parameter sets must include the frequency `ω`"))
     ω = Float64(p.ω)
     ε⁻¹ = prob.ε⁻¹
@@ -74,7 +122,7 @@ function _solve_and_summarize(p::NamedTuple, prob::NamedTuple, solver, nev::Int,
     # power `P` (W). Each band is corrected assuming the full power in that mode.
     P = haskey(p, :P) ? Float64(p.P) : 0.0
     local kmags, evecs, kmags_lin, dn_max
-    if P > 0 && hasproperty(prob, :n₂)
+    if allow_kerr && P > 0 && hasproperty(prob, :n₂)
         res = solve_k_kerr(ω, P, ε⁻¹, ∂ε_∂ω, prob.n₂, grid, solver; nev, solver_kwargs...)
         kmags, evecs = res.kmags, res.evecs
         kmags_lin, dn_max = res.kmags_lin, res.dn_max
@@ -84,7 +132,7 @@ function _solve_and_summarize(p::NamedTuple, prob::NamedTuple, solver, nev::Int,
     end
 
     bands = Vector{Dict{String,Any}}(undef, length(kmags))
-    Es = save_fields ? Vector{Array{ComplexF64}}(undef, length(kmags)) : nothing
+    Es = need_E ? Vector{Array{ComplexF64}}(undef, length(kmags)) : nothing
     for (b, (kmag, ev)) in enumerate(zip(kmags, evecs))
         neff = kmag / ω
         local ng, gvd
@@ -98,7 +146,7 @@ function _solve_and_summarize(p::NamedTuple, prob::NamedTuple, solver, nev::Int,
         E = E⃗(kmag, copy(ev), ε⁻¹, ∂ε_∂ω, grid; canonicalize=true, normalized=true)
         Aeff = 𝓐(neff, ng, E)
         relpwr = E_relpower_xyz(ε, E)
-        bands[b] = Dict{String,Any}(
+        bd = Dict{String,Any}(
             "band" => b,
             "kmag" => kmag,
             "neff" => neff,
@@ -112,11 +160,76 @@ function _solve_and_summarize(p::NamedTuple, prob::NamedTuple, solver, nev::Int,
             "dneff_kerr" => (kmag - kmags_lin[b]) / ω,
             "dn_max" => dn_max[b],
         )
-        save_fields && (Es[b] = E)
+        _add_mode_label!(bd, E, grid, mode_labels, label_max_order)
+        bands[b] = bd
+        need_E && (Es[b] = E)
     end
     summary = Dict{String,Any}("omega" => ω, "bands" => bands, "nev" => length(kmags))
-    fields = save_fields ? (; ω, kmags, evecs, Es, grid) : nothing
-    return summary, fields
+    fields = need_E ? (; ω, kmags, evecs, Es, grid) : nothing
+    return summary, fields, Es
+end
+
+"classify a mode by Hermite–Gaussian fit (TE/TM, transverse order) and store it on `bd`"
+function _add_mode_label!(bd::Dict{String,Any}, E, grid, mode_labels::Bool, max_order::Int)
+    label, mp, mm, mn, rel, tef = "", "", 0, 0, NaN, NaN
+    if mode_labels && grid isa Grid{2}
+        try
+            nw = hg_mode_label(E, grid; max_order)
+            label, mp, mm, mn = nw.label, String(nw.pol), nw.m, nw.n
+            rel, tef = nw.rel_error, nw.te_frac
+        catch err
+            @warn "mode labeling failed; leaving label blank" exception = err
+        end
+    end
+    bd["label"] = label
+    bd["mode_pol"] = mp
+    bd["mode_m"] = mm
+    bd["mode_n"] = mn
+    bd["hg_rel_error"] = rel
+    bd["te_frac"] = tef
+    return bd
+end
+
+# ---------------------------------------------------------------------------------
+# field PNGs
+# ---------------------------------------------------------------------------------
+
+"ASCII mode label (e.g. TE00) for the PNG header — the 5×7 font has no subscripts"
+function _ascii_label(bd)
+    pol = get(bd, "mode_pol", "")
+    isempty(pol) && return ""
+    return string(pol, get(bd, "mode_m", 0), get(bd, "mode_n", 0))
+end
+
+"header lines (summary annotations) for the PNG of one band"
+function _png_header(summary, bd)
+    ω = get(summary, "omega", NaN)
+    λ = ω > 0 ? 1 / ω : NaN
+    f3(x) = (x isa Real && isfinite(x)) ? string(round(x; sigdigits=4)) : "n/a"
+    lines = String[
+        "TASK $(get(summary,"task","?"))  BAND $(get(bd,"band","?"))  $(_ascii_label(bd))",
+        "LAMBDA=$(f3(λ)) UM  NEFF=$(f3(get(bd,"neff",NaN)))  NG=$(f3(get(bd,"ng",NaN)))",
+        "GVD=$(f3(get(bd,"gvd",NaN)))  AEFF=$(f3(get(bd,"Aeff",NaN))) UM2",
+        "POL X/Y/Z = $(f3(get(bd,"pol_x",NaN)))/$(f3(get(bd,"pol_y",NaN)))/$(f3(get(bd,"pol_z",NaN)))",
+        "HOST $(get(summary,"node",get(summary,"host","?")))  T=$(f3(get(summary,"runtime_s",NaN)))S",
+    ]
+    return lines
+end
+
+"render & save one annotated PNG per band into the batch's tasks/ directory"
+function _write_plots(batch::BatchInfo, i::Int, summary, Es, grid)
+    Es === nothing && return nothing
+    base = _task_base(batch, i)
+    for (b, bd) in enumerate(summary["bands"])
+        b <= length(Es) || break
+        path = base * "_b" * @sprintf("%02i", b) * ".png"
+        try
+            render_mode_png(path, Es[b], grid, _png_header(summary, bd))
+        catch err
+            @warn "field PNG rendering failed for task $i band $b" exception = err
+        end
+    end
+    return nothing
 end
 
 "write full mode-field data for one task to HDF5"

--- a/lib/ModeSweeps/test/runtests.jl
+++ b/lib/ModeSweeps/test/runtests.jl
@@ -247,6 +247,113 @@ end
         @test batch.manifest["n_tasks"] == 6
     end
 
+    @testset "PNG rendering" begin
+        # read (width,height) from a PNG's IHDR (offsets are 1-based here)
+        png_dims(path) = let b = read(path)
+            be(o) = (Int(b[o]) << 24) | (Int(b[o+1]) << 16) | (Int(b[o+2]) << 8) | Int(b[o+3])
+            (be(17), be(21))
+        end
+        SIG = UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]
+
+        # low-level encoder: valid signature + correct dimensions
+        canvas = fill(UInt8(128), 11, 23, 3)
+        p0 = write_png(joinpath(TESTDIR, "raw.png"), canvas)
+        @test isfile(p0)
+        @test read(p0)[1:8] == SIG
+        @test png_dims(p0) == (23, 11)        # (width, height)
+
+        # composite mode image: 3 |Eᵢ| panels + annotation header
+        grid = Grid(4.0, 3.0, 20, 14)
+        Nx, Ny = size(grid)
+        E = zeros(ComplexF64, 3, Nx, Ny)
+        for ix in 1:Nx, iy in 1:Ny
+            E[1, ix, iy] = exp(-((ix - Nx / 2)^2 / 9 + (iy - Ny / 2)^2 / 4))
+            E[2, ix, iy] = 0.3 * exp(-((ix - Nx / 3)^2 / 9 + (iy - Ny / 2)^2 / 4))
+        end
+        p = render_mode_png(joinpath(TESTDIR, "mode.png"), E, grid,
+            ["TASK 1 BAND 1 TE00", "NEFF=1.8 NG=2.1"])
+        @test isfile(p)
+        @test read(p)[1:8] == SIG
+        w, h = png_dims(p)
+        @test w > 3Nx && h > Ny               # 3 panels wide, header band on top
+    end
+
+    @testset "blocking deploy + wait_batch" begin
+        dir = joinpath(TESTDIR, "blocking")
+        batch = deploy_batch(SETUP_FILE, param_grid(ω=[0.6, 0.62], wx=[1.0]);
+            name="blk", dir, nev=1, backend=:local, blocking=true)
+        st = batch_status(batch; verbose=false)
+        @test st.done == 2 && st.pending == 0
+        st2 = wait_batch(batch; verbose=false)   # already complete → returns at once
+        @test st2.done == 2 && st2.pending == 0
+    end
+
+    @testset "save_plots, mode labels & metadata columns" begin
+        dir = joinpath(TESTDIR, "plots")
+        batch = deploy_batch(SETUP_FILE, param_grid(ω=[1 / 1.55], wx=[1.0]);
+            name="plotstest", dir, nev=2, save_plots=true, backend=:local,
+            solver_kwargs=(; k_tol=1e-10))
+        st = wait_for_batch(batch)
+        @test st.done == 1 && st.failed == 0
+
+        # one annotated PNG per band, each a valid PNG, transferred back
+        pngs = plot_paths(batch, 1)
+        @test length(pngs) == 2
+        @test all(p -> read(p)[1:8] == UInt8[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], pngs)
+
+        rows = gather_batch(batch; save=false)
+        r = first(rows)
+        for c in (:label, :mode_pol, :mode_m, :mode_n, :hg_rel_error, :te_frac,
+            :host, :runtime_s, :started, :finished, :slurm_job, :slurm_task)
+            @test hasproperty(r, c)
+        end
+        @test r.mode_pol in ("TE", "TM", "")
+        @test isempty(r.label) || startswith(r.label, "TE") || startswith(r.label, "TM")
+        @test r.runtime_s ≥ 0 && !isempty(r.host)
+        @test r.mode_m ≥ 0 && r.mode_n ≥ 0
+    end
+
+    @testset "remote AD: forward/backward as separate tasks" begin
+        p = (; ω=1 / 1.55, wx=1.0)
+        # in-process reference solve & adjoint (same rrule the worker uses)
+        prob = Base.invokelatest(make_problem, p)   # make_problem include'd earlier
+        kk, _ = solve_k(p.ω, copy(prob.ε⁻¹), prob.grid, KrylovKitEigsolve(); nev=1, k_tol=1e-10)
+        ω̄0, ei0 = ModeSweeps._remote_pullback(p.ω, prob.ε⁻¹, prob.grid,
+            KrylovKitEigsolve(), 1, [1.0], nothing)
+
+        # forward pass as its own task; persists primal + adjoint inputs to shared FS
+        fdir = joinpath(TESTDIR, "ad_fwd")
+        fwd = deploy_forward(SETUP_FILE, [p]; nev=1, dir=fdir, name="adf",
+            backend=:local, blocking=true, solver_kwargs=(; k_tol=1e-10))
+        @test batch_status(fwd; verbose=false).done == 1
+        sol = forward_solution(fwd, 1)
+        @test sol.ω ≈ p.ω
+        @test length(sol.kmags) == 1 && sol.kmags[1] ≈ kk[1] rtol = 1e-6
+        @test size(sol.ε⁻¹) == size(prob.ε⁻¹)
+
+        # backward pass as a separate task; loads forward state + cotangents from disk
+        bdir = joinpath(TESTDIR, "ad_bwd")
+        bw = deploy_backward(fwd, [(; k̄=[1.0])]; dir=bdir, name="adb",
+            backend=:local, blocking=true)
+        @test batch_status(bw; verbose=false).done == 1
+        g = gradient_result(bw, 1)
+        @test size(g.ε⁻¹_bar) == size(prob.ε⁻¹)
+        @test isfinite(g.ω_bar)
+        # round-trips through the filesystem to the exact in-process adjoint
+        @test g.ω_bar ≈ ω̄0 rtol = 1e-6
+        @test g.ε⁻¹_bar ≈ ei0 rtol = 1e-6
+
+        # one cotangent per forward task is required
+        @test_throws ArgumentError deploy_backward(fwd, [(; k̄=[1.0]), (; k̄=[1.0])]; backend=:none)
+
+        # one-shot blocking convenience: value + gradient in one call
+        res = remote_value_and_gradient(SETUP_FILE, p, [1.0]; nev=1, name="ad1",
+            dir=joinpath(TESTDIR, "ad_oneshot"), backend=:local, solver_kwargs=(; k_tol=1e-10))
+        @test res.kmags[1] ≈ kk[1] rtol = 1e-6
+        @test res.ω_bar ≈ ω̄0 rtol = 1e-6
+        @test size(res.ε⁻¹_bar) == size(prob.ε⁻¹)
+    end
+
     if get(ENV, "OPTIMODE_TEST_SLURM", "false") == "true"
         @testset "SLURM submission (opt-in)" begin
             @test Sys.which("sbatch") !== nothing


### PR DESCRIPTION
Extends the `lib/ModeSweeps` package so mode solves and sweeps can run on a remote SLURM cluster with both blocking and asynchronous calls, richer results, annotated images, and full automatic-differentiation support. Builds on the existing batch-deployment scaffold (SLURM array jobs, ssh/rsync transfer, cross-session persistence, status monitoring, partial gathering).

## Blocking and asynchronous calls
- `deploy_batch`/`frequency_sweep` gain `blocking=true` (synchronous) alongside the default async deployment.
- New exported `wait_batch(batch; timeout, poll)` works across Julia sessions and machines (rsync-fetches markers in ssh mode).

## Richer worker-computed summaries
- Per-band summary now also carries the **mode-character label** (TE/TM + transverse Hermite–Gaussian order via `hg_mode_label`), fit goodness and TE fraction, plus execution metadata: **worker host, SLURM job/array-task ids, start/end time and run time**. `gather_batch` surfaces these as table columns.

## Annotated mode-field PNGs (`save_plots=true`)
- New **dependency-free** renderer (pure-Julia PNG encoder using stored DEFLATE blocks, viridis colormap and a 5×7 bitmap font) draws `|Ex|`,`|Ey|`,`|Ez|` panels annotated with the per-band summary, on any headless SLURM node, for both full-field and summary-only batches.
- PNGs transfer back over rsync; `plot_paths(batch, i)` finds them. Exposes `render_mode_png`/`write_png`.

## Remote automatic differentiation
- `deploy_forward`/`forward_solution` run the primal `solve_k` and persist the adjoint inputs (`ω, ε⁻¹, ∂ε/∂ω, grid, k, evecs, solver`) to the shared filesystem.
- `deploy_backward`/`gradient_result` run the `solve_k` adjoint `rrule` as a **separate SLURM task** reading that state plus output cotangents, writing input cotangents `(ω̄, ε̄⁻¹)`.
- `remote_value_and_gradient` ties both passes into one blocking call. Forward and backward thus run as different tasks exchanging data on the shared FS. The `k̄`-cotangent path (objectives built from neff/ng/GVD/Aeff) is exact.

## Docs and examples
- Expanded `docs/mode_sweeps.md` (summary columns, PNGs, blocking, remote-AD diagram); updated README.
- Added `examples/ridge_wg_setup.jl`, `remote_mode_solve.jl`, `remote_adjoint_optimization.jl`.
- Added tests for the renderer, blocking/`wait_batch`, metadata/label columns, `save_plots`, and the forward/backward AD round-trip.

## Notes
- Adds `ChainRulesCore` to `lib/ModeSweeps/Project.toml` deps (used to invoke the `solve_k` adjoint `rrule`).
- The development environment had no `julia`/`rsync`/`sbatch`/`ssh`, so the test suite was **not** run here — changes were verified by inspection against existing code paths and the `solve_k` adjoint internals. Recommend running `julia --project=lib/ModeSweeps -e 'using Pkg; Pkg.test()'` on an instantiated environment before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFP6p4mC7mp22agbsm4qad

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFP6p4mC7mp22agbsm4qad)_