### PR TITLE
EME: (cell×ω) batched deploy, cross-section dedup, warm starts, diagnostics

### DIFF
--- a/examples/eme_adiabatic_coupler.jl
+++ b/examples/eme_adiabatic_coupler.jl
@@ -77,18 +77,19 @@ end
 
 # ── 5. remote deployment (SLURM) & parameter sweeps ──────────────────────────
 # The per-cell mode solves are the expensive part and map onto ModeSweeps tasks.
-# With ModeSweeps loaded, deploy them as a SLURM array job (one task per cell),
-# then re-assemble the device S-matrix locally:
+# With ModeSweeps loaded, deploy the n_cells × n_ω cross-section solves as one SLURM
+# array job (identical cross-sections deduplicated), then re-assemble per frequency:
 #
 #     using ModeSweeps
 #     grid  = simulation_grid(structure, 128, 64)
 #     cells = build_cells(structure; num_cells=30)
+#     ωs    = 1 ./ (1.50:0.01:1.60)
 #     # eme_coupler_setup.jl defines  make_problem(p) = cell_problem(CELLS[p.cell], MATS, p.ω, GRID)
-#     batch = deploy_eme("examples/eme_coupler_setup.jl", length(cells);
-#                        ω = 1/1.55, nev = 2,
+#     batch = deploy_eme("examples/eme_coupler_setup.jl", cells;     # dedup'd (cell × ω)
+#                        ω = ωs, nev = 2,
 #                        slurm = SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/eme"))
-#     res   = gather_eme(batch, cells, structure.stack.materials, 1/1.55, grid; nev=2)
-#     power_coupling(res; in_mode=1, out_mode=2)
+#     results = gather_eme(batch, cells, structure.stack.materials, ωs, grid)  # one per ω
+#     power_coupling(results[1]; in_mode=1, out_mode=2)
 #
 # AD: `power_coupling`/`transmission` are differentiable, so a frequency- or
 # geometry-gradient of the coupling follows from Zygote (reverse) over `eme`:

--- a/examples/eme_coupler_setup.jl
+++ b/examples/eme_coupler_setup.jl
@@ -1,10 +1,11 @@
 # ModeSweeps setup script for deploying an EME stack's per-cell mode solves as a
-# SLURM batch (one task per cell). It is copied into the batch directory and
+# SLURM batch (one task per (cell, ω)). It is copied into the batch directory and
 # `include`d by every worker, so it `using`s what it needs and defines
 # `make_problem(p)`; here `p.cell` selects the EME cell and `p.ω` the frequency.
 #
-# Pair with `deploy_eme(@__FILE__, length(CELLS); ω, nev=2, ...)` and re-assemble
-# the device S-matrix with `gather_eme(batch, CELLS, MATS, ω, GRID; nev=2)`.
+# Pair with `deploy_eme(@__FILE__, CELLS; ω, nev=2, ...)` (dedup'd cell × ω tasks;
+# `ω` may be a vector) and re-assemble per frequency with
+# `gather_eme(batch, CELLS, MATS, ω, GRID)`.
 
 using EigenmodeExpansion
 using MaterialDispersion: Si₃N₄, SiO₂

--- a/lib/EigenmodeExpansion/README.md
+++ b/lib/EigenmodeExpansion/README.md
@@ -64,18 +64,48 @@ are marked non-differentiable. `test/runtests.jl` checks forward-mode dielectric
 sensitivities and reverse-mode end-to-end `ε⁻¹` sensitivities against
 `FiniteDifferences.jl`.
 
+## Performance: dedup, warm starts, convergence
+
+The expensive work is the per-cell eigensolves. Three knobs reduce and certify it:
+
+- **`dedup=true`** (default of `eme`) solves each *unique* cross-section once and shares
+  the modal basis across every cell with identical geometry — uniform/repeated stacks
+  (straight sections, grating periods) collapse to one solve per distinct geometry, with
+  no change to the result. `dedup_groups(cells)` exposes the grouping; `cross_section_key`
+  the per-cell key.
+- **`warmstart=true`** seeds each successive cell's Newton/eigensolver iterations from the
+  previous cell's solution (`solve_k`'s `kguess`/`Hguess`), cutting iteration counts on
+  slowly-varying (adiabatic) devices. It only seeds the solver, so the converged S-matrix
+  is unchanged.
+- **`nev_convergence` / `passivity_report`** certify the modal-basis truncation. A
+  truncated basis shows up as a non-passive raw interface (`σ > 1`); raise `nev` until
+  `passivity_report(res).max_excess → 0`, at which point the (AD-friendly) `passivity=:none`
+  adjoint matches the enforced primal:
+
+  ```julia
+  conv = nev_convergence(structure, 1/1.55; nevs=1:6, num_cells=30)   # values, deltas, max_excess
+  rep  = passivity_report(res)                                        # per-interface σ-excess
+  ```
+
 ## SLURM / parameter sweeps
 
-The per-cell mode solves map one-to-one onto ModeSweeps tasks. With `ModeSweeps`
-loaded, deploy them as a SLURM array job and re-assemble locally:
+The whole `n_cells × n_ω` set of cross-section solves is independent and farms as one
+SLURM array job. Pass the `cells` (so identical cross-sections are deduplicated) and a
+**vector `ω`** to sweep frequency and cells together; `gather_eme` reduces per frequency,
+returning one `EMEResult` per `ω`:
 
 ```julia
 using ModeSweeps
 grid  = simulation_grid(structure, 128, 64)
 cells = build_cells(structure; num_cells=30)
-batch = deploy_eme("examples/eme_coupler_setup.jl", length(cells);
-                   ω=1/1.55, nev=2, slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/eme"))
-res   = gather_eme(batch, cells, structure.stack.materials, 1/1.55, grid; nev=2)
+ωs    = 1 ./ (1.50:0.01:1.60)
+batch = deploy_eme("examples/eme_coupler_setup.jl", cells;          # dedup'd (cell × ω) tasks
+                   ω=ωs, nev=2, slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/eme"))
+results = gather_eme(batch, cells, structure.stack.materials, ωs, grid; nev=2)   # Vector{EMEResult}
 ```
+
+The setup script's `make_problem(p)` returns the cell-`p.cell` cross-section at `p.ω` (see
+`cell_problem`). The legacy `deploy_eme(setup_file, num_cells::Int; ω, …)` form (one task
+per cell, no dedup) is still available.
 
 Full documentation: [`docs/eigenmode_expansion.md`](../../docs/eigenmode_expansion.md).

--- a/lib/EigenmodeExpansion/ext/EigenmodeExpansionModeSweepsExt.jl
+++ b/lib/EigenmodeExpansion/ext/EigenmodeExpansionModeSweepsExt.jl
@@ -1,18 +1,31 @@
 # ModeSweeps integration for EigenmodeExpansion.
 #
-# EME's per-cell mode solves are deployed as a ModeSweeps batch (one task per
-# cell, swept over the cell index and frequency); the device S-matrix is then
-# re-assembled locally from the gathered per-cell fields. This reuses the
-# existing SLURM array-job / parameter-sweep machinery unchanged — each EME cell
-# is just a `make_problem` cross-section.
+# EME's per-cell mode solves are deployed as a ModeSweeps batch, one task per
+# (cell, ω): the whole n_cells × n_ω set of cross-section eigensolves is independent
+# and farmed as a single SLURM array job. The device S-matrix is re-assembled locally
+# per frequency from the gathered per-cell fields. Identical cross-sections are solved
+# once (dedup) and shared. This reuses the existing SLURM array-job / parameter-sweep
+# machinery unchanged — each EME cell is just a `make_problem` cross-section.
 
 module EigenmodeExpansionModeSweepsExt
 
 using EigenmodeExpansion
-using EigenmodeExpansion: Cell, assemble_eme
+using EigenmodeExpansion: Cell, assemble_eme, dedup_groups, _eme_task_map, _eme_task_index
 using ModeSweeps
 using ModeSweeps: param_grid, deploy_batch, wait_batch, load_fields, SlurmConfig, BatchInfo
 
+# Deploy with explicit cells: dedup identical cross-sections and farm (representative
+# cell × ω) tasks. `gather_eme` maps every cell back to its representative.
+function EigenmodeExpansion.deploy_eme(setup_file::AbstractString, cells::AbstractVector{Cell};
+        ω, nev::Int=2, dedup::Bool=true, name::AbstractString="eme", backend::Symbol=:slurm,
+        slurm::SlurmConfig=SlurmConfig(), blocking::Bool=false, kwargs...)
+    reps, _ = dedup ? dedup_groups(cells) : (collect(eachindex(cells)), nothing)
+    params = param_grid(; cell=reps, ω=ω)                 # (representative cell × ω), cell fastest
+    return deploy_batch(setup_file, params; name, nev, save_fields=true,
+        backend, slurm, blocking, kwargs...)
+end
+
+# Deploy by cell count (legacy, no dedup): one task per (cell, ω).
 function EigenmodeExpansion.deploy_eme(setup_file::AbstractString, num_cells::Int;
         ω, nev::Int=2, name::AbstractString="eme", backend::Symbol=:slurm,
         slurm::SlurmConfig=SlurmConfig(), blocking::Bool=false, kwargs...)
@@ -22,19 +35,27 @@ function EigenmodeExpansion.deploy_eme(setup_file::AbstractString, num_cells::In
 end
 
 function EigenmodeExpansion.gather_eme(batch::BatchInfo, cells::AbstractVector{Cell},
-        materials, ω, grid; conjugate::Bool=false, reg::Real=1e-9,
-        reciprocity::Bool=true, wait::Bool=true)
+        materials, ω, grid; dedup::Bool=true, conjugate::Bool=false, reg::Real=1e-9,
+        reciprocity::Bool=true, passivity::Symbol=:invert, wait::Bool=true)
     wait && wait_batch(batch)
     n = length(cells)
-    kmags_per_cell = Vector{Vector{Float64}}(undef, n)
-    evecs_per_cell = Vector{Vector{Vector{ComplexF64}}}(undef, n)
-    for i in 1:n
-        lf = load_fields(batch, i)                        # task i ↔ cell i (cell varies fastest)
-        kmags_per_cell[i] = collect(Float64.(lf.kmags))
-        evecs_per_cell[i] = [collect(ComplexF64.(ev)) for ev in lf.evecs]
+    reps, _ = dedup ? dedup_groups(cells) : (collect(1:n), nothing)
+    tmap = _eme_task_map(batch.params)
+    ωs = ω isa Number ? [ω] : collect(ω)
+
+    results = map(ωs) do ωj
+        kmags_per_rep = Vector{Vector{Float64}}(undef, length(reps))
+        evecs_per_rep = Vector{Vector{Vector{ComplexF64}}}(undef, length(reps))
+        for (k, ci) in enumerate(reps)
+            t = _eme_task_index(tmap, ci, ωj)             # task solving representative cell ci at ωj
+            lf = load_fields(batch, t)
+            kmags_per_rep[k] = collect(Float64.(lf.kmags))
+            evecs_per_rep[k] = [collect(ComplexF64.(ev)) for ev in lf.evecs]
+        end
+        assemble_eme(cells, kmags_per_rep, evecs_per_rep, materials, ωj, grid;
+            conjugate, reg, reciprocity, passivity, dedup)
     end
-    return assemble_eme(cells, kmags_per_cell, evecs_per_cell, materials, ω, grid;
-        conjugate, reg, reciprocity)
+    return ω isa Number ? only(results) : results
 end
 
 end # module

--- a/lib/EigenmodeExpansion/src/EigenmodeExpansion.jl
+++ b/lib/EigenmodeExpansion/src/EigenmodeExpansion.jl
@@ -31,9 +31,11 @@ import GeometryPrimitives
 
 include("gds.jl")
 include("structure.jl")
+include("cache.jl")
 include("modes.jl")
 include("smatrix.jl")
 include("eme.jl")
+include("diagnostics.jl")
 include("sweeps.jl")
 
 # Discrete / IO operations are constants for AD: the EME differentiable variables

--- a/lib/EigenmodeExpansion/src/cache.jl
+++ b/lib/EigenmodeExpansion/src/cache.jl
@@ -1,0 +1,73 @@
+# ──────────────────────────────────────────────────────────────────────────────
+#  Cross-section de-duplication.
+#
+#  An EME stack of `num_cells` cells very often contains long uniform (or repeated)
+#  runs — straight waveguide sections, identical grating periods — whose cells have
+#  *geometrically identical* cross-sections. At a fixed grid and material list the
+#  smoothed dielectric, and therefore the modal basis, is then bit-for-bit the same,
+#  so the (expensive) mode solve only needs to run once per *unique* cross-section
+#  and the result can be shared by every cell in that group.
+#
+#  This is the spatial-axis counterpart of caching the geometry smoothing across
+#  frequency: here we collapse identical cells; the per-ω material reuse inside
+#  `smooth_ε` is a separate (DielectricSmoothing-level) optimisation.
+# ──────────────────────────────────────────────────────────────────────────────
+
+export cross_section_key, dedup_groups
+
+# Canonicalise a Float to a rounded integer multiple of `atol` so that geometrically
+# identical cells (whose shape parameters are computed by identical arithmetic) hash and
+# compare equal, while genuinely different cross-sections do not collide.
+_q(x::Real; atol::Float64=1e-9) = round(Int, x / atol)
+
+"""
+    cross_section_key(cs::CrossSection; atol=1e-9) -> key
+
+A hashable, `==`-comparable canonical key for a [`CrossSection`](@ref): two cells with
+equal keys have the same shapes (each `Cuboid`'s centre, half-widths and axes, quantised
+to `atol` μm) in the same order with the same material indices, hence an identical
+smoothed dielectric on a given grid. Used by [`dedup_groups`](@ref) to solve each unique
+cross-section's modes only once.
+"""
+function cross_section_key(cs::CrossSection; atol::Float64=1e-9)
+    shape_keys = map(cs.shapes) do ms
+        b = ms.shape                                   # GeometryPrimitives.Cuboid
+        c = Tuple(_q.(b.c; atol))                      # centre
+        r = Tuple(_q.(2 .* b.r; atol))                 # full widths (r = half-widths)
+        a = Tuple(_q.(vec(Matrix(b.p)); atol))         # axis matrix
+        (c, r, a)
+    end
+    return (Tuple(shape_keys), Tuple(cs.minds))
+end
+
+"""
+    dedup_groups(cells; atol=1e-9) -> (reps, gid)
+
+Group cells by identical cross-section. Returns `reps`, the indices of the first cell of
+each unique cross-section (the representatives to actually solve), and `gid`, a vector
+mapping every cell to the position in `reps` of its group, so that
+
+    modes_per_cell[i] = modes_of_representative[gid[i]]
+
+shares one modal basis across all cells with the same geometry. For a stack of all-distinct
+cross-sections (a fully tapered device) `reps == 1:length(cells)` and this is a no-op.
+"""
+function dedup_groups(cells::AbstractVector{Cell}; atol::Float64=1e-9)
+    keys = [cross_section_key(c.cross_section; atol) for c in cells]
+    reps = Int[]
+    key_to_group = Dict{Any,Int}()
+    gid = Vector{Int}(undef, length(cells))
+    for (i, k) in enumerate(keys)
+        g = get(key_to_group, k, 0)
+        if g == 0
+            push!(reps, i)
+            g = length(reps)
+            key_to_group[k] = g
+        end
+        gid[i] = g
+    end
+    return reps, gid
+end
+
+@non_differentiable cross_section_key(::Any)
+@non_differentiable dedup_groups(::Any)

--- a/lib/EigenmodeExpansion/src/diagnostics.jl
+++ b/lib/EigenmodeExpansion/src/diagnostics.jl
@@ -1,0 +1,94 @@
+# ──────────────────────────────────────────────────────────────────────────────
+#  Convergence / accuracy diagnostics.
+#
+#  EME accuracy rests on two coupled choices: the number of cells (z-discretisation)
+#  and the number of modes per cell `nev` (modal-basis truncation). A truncated
+#  basis shows up as a *non-passive* raw interface S-matrix (singular values σ > 1) —
+#  the very thing `enforce_passivity` masks. Since the passivity SVD is not
+#  reverse-mode-AD friendly (differentiate with `passivity=:none`), the right recipe
+#  is to raise `nev` until the raw interfaces are passive on their own, then the
+#  `:none` adjoint matches the physical primal. These helpers measure both.
+# ──────────────────────────────────────────────────────────────────────────────
+
+export passivity_report, nev_convergence
+
+"""
+    passivity_report(modes; conjugate=false, reg=1e-9) -> NamedTuple
+    passivity_report(result::EMEResult; …) -> NamedTuple
+
+Quantify modal-truncation error by how far each *raw* (un-enforced) interface S-matrix
+exceeds passivity. For every adjacent pair of cells the interface S-matrix is rebuilt with
+`passivity=:none` and its largest singular value taken; the report returns
+
+- `per_interface :: Vector{Float64}` — `max(σ) - 1` for each interface (0 ⇒ passive),
+- `max_excess :: Float64` — the worst interface,
+- `passive :: Bool` — whether `max_excess ≤ tol` (`tol = 1e-6`).
+
+A large `max_excess` means `nev` is too small (or cells too coarse) and the passivity
+enforcement is doing real work — so a `passivity=:none` adjoint would not match the
+enforced primal. Drive `max_excess → 0` (raise `nev`) for trustworthy gradients.
+"""
+function passivity_report(modes::AbstractVector; conjugate::Bool=false, reg::Real=1e-9,
+                          tol::Real=1e-6)
+    n = length(modes)
+    n ≥ 2 || return (; per_interface=Float64[], max_excess=0.0, passive=true)
+    per = Vector{Float64}(undef, n - 1)
+    for i in 1:(n - 1)
+        S = interface_smatrix(modes[i], modes[i+1]; conjugate, reg, reciprocity=false, passivity=:none)
+        per[i] = maximum(svdvals(S.S)) - 1.0
+    end
+    mx = maximum(per)
+    return (; per_interface=per, max_excess=mx, passive=(mx ≤ tol))
+end
+
+passivity_report(r::EMEResult; kwargs...) = passivity_report(r.modes; kwargs...)
+
+"""
+    nev_convergence(cells, materials, ω, grid, solver=KrylovKitEigsolve();
+                    nevs=1:4, objective=power_coupling, conjugate=false, reg=1e-9,
+                    reciprocity=true, kwargs...) -> NamedTuple
+
+Sweep the modal-basis size and report convergence of a scalar `objective(result)` (default
+[`power_coupling`](@ref)). For each `nev ∈ nevs` an EME run is performed (with `dedup` so
+repeated cross-sections cost nothing extra) and the report returns
+
+- `nevs :: Vector{Int}`,
+- `values :: Vector{Float64}` — `objective` at each `nev`,
+- `deltas :: Vector{Float64}` — `|value[j] − value[j-1]|` (first entry `NaN`),
+- `max_excess :: Vector{Float64}` — the [`passivity_report`](@ref) worst interface at each
+  `nev` (should fall toward 0 as the basis converges).
+
+Pick the smallest `nev` whose `deltas` and `max_excess` are both below your tolerance.
+`kwargs` are forwarded to `solve_k`.
+"""
+function nev_convergence(cells::AbstractVector{Cell}, materials, ω, grid,
+                         solver::AbstractEigensolver=KrylovKitEigsolve();
+                         nevs=1:4, objective=power_coupling, conjugate::Bool=false,
+                         reg::Real=1e-9, reciprocity::Bool=true, kwargs...)
+    nv = collect(Int, nevs)
+    values = Vector{Float64}(undef, length(nv))
+    excess = Vector{Float64}(undef, length(nv))
+    for (j, nev) in enumerate(nv)
+        r = eme(cells, materials, ω, grid, solver; nev, conjugate, reg, reciprocity,
+                passivity=:invert, kwargs...)
+        values[j] = float(objective(r))
+        excess[j] = passivity_report(r; conjugate, reg).max_excess
+    end
+    deltas = [j == 1 ? NaN : abs(values[j] - values[j-1]) for j in eachindex(values)]
+    return (; nevs=nv, values, deltas, max_excess=excess)
+end
+
+"""
+    nev_convergence(structure, ω; nevs=1:4, Nx=128, Ny=96, num_cells=20,
+                    solver=KrylovKitEigsolve(), objective=power_coupling, kwargs...)
+
+Convenience method building the grid and cells from a [`Structure`](@ref) (cf.
+[`eme_smatrix`](@ref)) before sweeping `nev`.
+"""
+function nev_convergence(st::Structure, ω; nevs=1:4, Nx::Int=128, Ny::Int=96,
+                         num_cells::Int=20, solver::AbstractEigensolver=KrylovKitEigsolve(),
+                         objective=power_coupling, kwargs...)
+    grid = simulation_grid(st, Nx, Ny)
+    cells = build_cells(st; num_cells)
+    return nev_convergence(cells, st.stack.materials, ω, grid, solver; nevs, objective, kwargs...)
+end

--- a/lib/EigenmodeExpansion/src/eme.jl
+++ b/lib/EigenmodeExpansion/src/eme.jl
@@ -26,21 +26,51 @@ end
 
 """
     eme(cells, materials, ω, grid, solver=KrylovKitEigsolve();
-        nev=2, conjugate=false, reg=1e-9, reciprocity=true, kwargs...) -> EMEResult
+        nev=2, conjugate=false, reg=1e-9, reciprocity=true, passivity=:invert,
+        dedup=true, warmstart=false, kwargs...) -> EMEResult
 
 Run eigenmode expansion over a vector of [`Cell`](@ref)s. Each cell's cross-section
 is solved for `nev` modes; adjacent cells are coupled through MEOW interface
 S-matrices and joined by diagonal propagation S-matrices, then cascaded.
-`kwargs` are forwarded to `solve_k`.
+
+`dedup=true` (default) solves each *unique* cross-section's modes only once and shares
+the modal basis across all cells with identical geometry (see [`dedup_groups`](@ref)) —
+a large saving for stacks with uniform/repeated sections, with no effect on the result.
+`warmstart=true` seeds each successive cell's eigensolve from the previous one's solution
+(`kguess`/`Hguess`), cutting Newton/Lanczos iterations on slowly-varying (adiabatic)
+stacks. `kwargs` are forwarded to `solve_k`.
 """
 function eme(cells::AbstractVector{Cell}, materials, ω, grid,
              solver::AbstractEigensolver=KrylovKitEigsolve();
              nev::Int=2, conjugate::Bool=false, reg::Real=1e-9,
-             reciprocity::Bool=true, passivity::Symbol=:invert, kwargs...)
-    modes = [solve_cell_modes(c, materials, ω, grid, solver; nev, conjugate, kwargs...) for c in cells]
+             reciprocity::Bool=true, passivity::Symbol=:invert,
+             dedup::Bool=true, warmstart::Bool=false, kwargs...)
+    modes = _solve_cells(cells, materials, ω, grid, solver; nev, conjugate, dedup, warmstart, kwargs...)
     S = _assemble(modes, [c.length for c in cells]; conjugate, reg, reciprocity, passivity)
     T = typeof(float(ω))
     return EMEResult{T}(S, modes, [c.length for c in cells], T(ω))
+end
+
+# Solve the modal basis of every cell, de-duplicating identical cross-sections and
+# (optionally) warm-starting each unique solve from the previous one. Returns one
+# `Modes` per cell; cells in the same dedup group share the *same* `Modes` object.
+function _solve_cells(cells::AbstractVector{Cell}, materials, ω, grid, solver;
+                      nev::Int, conjugate::Bool, dedup::Bool, warmstart::Bool, kwargs...)
+    reps, gid = dedup ? dedup_groups(cells) : (collect(eachindex(cells)), collect(eachindex(cells)))
+    prev_k = Ref{Any}(nothing)
+    prev_H = Ref{Any}(nothing)
+    rep_modes = map(reps) do ci
+        kg, hg = warmstart ? (prev_k[], prev_H[]) : (nothing, nothing)
+        kmags, evecs, ε⁻¹, ∂ε_∂ω = _cell_raw_solve(cells[ci], materials, ω, grid, solver;
+                                                    nev, kguess=kg, Hguess=hg, kwargs...)
+        if warmstart
+            ChainRulesCore.ignore_derivatives() do
+                prev_k[] = copy(kmags); prev_H[] = [copy(ev) for ev in evecs]
+            end
+        end
+        [build_mode(ω, kmags[i], evecs[i], ε⁻¹, ∂ε_∂ω, grid; conjugate) for i in 1:nev]
+    end
+    return [rep_modes[g] for g in gid]
 end
 
 """

--- a/lib/EigenmodeExpansion/src/modes.jl
+++ b/lib/EigenmodeExpansion/src/modes.jl
@@ -119,17 +119,29 @@ function build_mode(ω, k, evec, ε⁻¹, ∂ε_∂ω, grid; conjugate::Bool=fal
     return Mode(ω, k, complex(k / ω), E ./ nrm, H ./ nrm, δA)
 end
 
+# Lower-level cell solve returning the raw eigensolution alongside the dielectric, so the
+# `(kmags, evecs)` of one cell can warm-start the next (`kguess`/`Hguess`). The warm-start
+# seeds are forwarded as `solve_k` keyword arguments and so do not participate in AD.
+function _cell_raw_solve(cell::Cell, materials, ω, grid, solver::AbstractEigensolver;
+                         nev::Int=2, kguess=nothing, Hguess=nothing, kwargs...)
+    ε⁻¹, ∂ε_∂ω = cell_dielectric(cell.cross_section, materials, ω, grid)
+    kmags, evecs = solve_k(ω, ε⁻¹, grid, solver; nev, kguess, Hguess, kwargs...)
+    return kmags, evecs, ε⁻¹, ∂ε_∂ω
+end
+
 """
-    solve_cell_modes(cell, materials, ω, grid, solver; nev=2, conjugate=false, kwargs...) -> Modes
+    solve_cell_modes(cell, materials, ω, grid, solver; nev=2, conjugate=false,
+                     kguess=nothing, Hguess=nothing, kwargs...) -> Modes
 
 Solve the `nev` lowest modes of `cell`'s cross-section. `kwargs` are forwarded to
-`MaxwellEigenmodes.solve_k` (e.g. `k_tol`, `maxiter`). The returned modes are the
-modal basis for that cell in the EME expansion.
+`MaxwellEigenmodes.solve_k` (e.g. `k_tol`, `maxiter`). Optional `kguess` (an initial `|k|`)
+and `Hguess` (an initial transverse-`H` eigenvector basis, e.g. the previous cell's
+`evecs`) warm-start the Newton/eigensolver iterations without changing the converged
+result. The returned modes are the modal basis for that cell in the EME expansion.
 """
 function solve_cell_modes(cell::Cell, materials, ω, grid, solver::AbstractEigensolver=KrylovKitEigsolve();
-                          nev::Int=2, conjugate::Bool=false, kwargs...)
-    ε⁻¹, ∂ε_∂ω = cell_dielectric(cell.cross_section, materials, ω, grid)
-    kmags, evecs = solve_k(ω, ε⁻¹, grid, solver; nev, kwargs...)
+                          nev::Int=2, conjugate::Bool=false, kguess=nothing, Hguess=nothing, kwargs...)
+    kmags, evecs, ε⁻¹, ∂ε_∂ω = _cell_raw_solve(cell, materials, ω, grid, solver; nev, kguess, Hguess, kwargs...)
     return [build_mode(ω, kmags[i], evecs[i], ε⁻¹, ∂ε_∂ω, grid; conjugate) for i in 1:nev]
 end
 

--- a/lib/EigenmodeExpansion/src/sweeps.jl
+++ b/lib/EigenmodeExpansion/src/sweeps.jl
@@ -12,22 +12,51 @@
 export cell_problem, assemble_eme, deploy_eme, gather_eme
 
 """
-    deploy_eme(setup_file, num_cells; ω, nev=2, kwargs...) -> BatchInfo
+    deploy_eme(setup_file, cells; ω, nev=2, dedup=true, kwargs...) -> BatchInfo
+    deploy_eme(setup_file, num_cells::Int; ω, nev=2, kwargs...) -> BatchInfo
 
-Deploy the per-cell mode solves of an EME stack as a ModeSweeps batch (one SLURM
-array task per cell). Requires `ModeSweeps` to be loaded; see the
-`EigenmodeExpansionModeSweepsExt` extension. The `setup_file`'s `make_problem(p)`
-should return the cell-`p.cell` cross-section problem (see [`cell_problem`](@ref)).
+Deploy the per-cell mode solves of an EME stack as a ModeSweeps batch. The expensive
+work — `n_cells × n_ω` cross-section eigensolves — is fully independent and farmed as one
+SLURM array job: pass a vector `ω` to sweep frequency and cells together in a single batch
+(one task per `(cell, ω)`), then reduce per ω at gather time. With the `cells` method and
+`dedup=true` (default), only the *unique* cross-sections are enqueued (see
+[`dedup_groups`](@ref)); [`gather_eme`](@ref) maps every cell back to its representative
+task, so uniform/repeated stacks cost one solve per distinct geometry per frequency.
+
+Requires `ModeSweeps` to be loaded (see the `EigenmodeExpansionModeSweepsExt` extension).
+The `setup_file`'s `make_problem(p)` should return the cell-`p.cell` cross-section problem
+at frequency `p.ω` (see [`cell_problem`](@ref)).
 """
 function deploy_eme end
 
 """
-    gather_eme(batch, cells, materials, ω, grid; kwargs...) -> EMEResult
+    gather_eme(batch, cells, materials, ω, grid; dedup=true, kwargs...)
+        -> EMEResult | Vector{EMEResult}
 
-Gather a completed [`deploy_eme`](@ref) batch and re-assemble the device
-S-matrix. Requires `ModeSweeps` to be loaded.
+Gather a completed [`deploy_eme`](@ref) batch and re-assemble the device S-matrix. With a
+scalar `ω` one [`EMEResult`](@ref) is returned; with a vector `ω` one result per frequency
+(in order) is returned. Each cell's modes are taken from its dedup representative's task
+(`dedup` must match the `deploy_eme` call). Requires `ModeSweeps` to be loaded.
 """
 function gather_eme end
+
+# ── (cell, ω) → task-index mapping (pure; operates on the batch's parameter list) ──
+
+# Quantise ω to an integer key so a gather-time ω matches the deploy-time ω despite any
+# float round-trip; ω is O(1) μm⁻¹ so 1e-12 absolute resolution is unambiguous.
+_ωkey(ω::Real; atol::Float64=1e-12) = round(Int, ω / atol)
+
+"build a `(cell, ω) → task index` lookup from a batch's `(; cell, ω, …)` parameter list"
+function _eme_task_map(params::AbstractVector; atol::Float64=1e-12)
+    d = Dict{Tuple{Int,Int},Int}()
+    for (t, p) in enumerate(params)
+        d[(Int(p.cell), _ωkey(p.ω; atol))] = t
+    end
+    return d
+end
+
+_eme_task_index(d::AbstractDict, cell::Int, ω::Real; atol::Float64=1e-12) =
+    d[(cell, _ωkey(ω; atol))]
 
 """
     cell_problem(cell, materials, ω, grid) -> NamedTuple
@@ -63,14 +92,18 @@ in [`eme`](@ref).
 """
 function assemble_eme(cells::AbstractVector{Cell}, kmags_per_cell, evecs_per_cell,
                       materials, ω, grid; conjugate::Bool=false, reg::Real=1e-9,
-                      reciprocity::Bool=true)
+                      reciprocity::Bool=true, passivity::Symbol=:invert, dedup::Bool=true)
     n = length(cells)
-    modes = map(1:n) do i
-        ε⁻¹, ∂ε_∂ω = cell_dielectric(cells[i].cross_section, materials, ω, grid)
-        [build_mode(ω, kmags_per_cell[i][j], evecs_per_cell[i][j], ε⁻¹, ∂ε_∂ω, grid; conjugate)
-         for j in eachindex(kmags_per_cell[i])]
+    reps, gid = dedup ? dedup_groups(cells) : (collect(1:n), collect(1:n))
+    # reconstruct each unique cross-section's modes once, then share across its group
+    rep_modes = map(eachindex(reps)) do k
+        ci = reps[k]
+        ε⁻¹, ∂ε_∂ω = cell_dielectric(cells[ci].cross_section, materials, ω, grid)
+        [build_mode(ω, kmags_per_cell[k][j], evecs_per_cell[k][j], ε⁻¹, ∂ε_∂ω, grid; conjugate)
+         for j in eachindex(kmags_per_cell[k])]
     end
-    S = _assemble(modes, [c.length for c in cells]; conjugate, reg, reciprocity)
+    modes = [rep_modes[g] for g in gid]
+    S = _assemble(modes, [c.length for c in cells]; conjugate, reg, reciprocity, passivity)
     T = typeof(float(ω))
     return EMEResult{T}(S, modes, [c.length for c in cells], T(ω))
 end

--- a/lib/EigenmodeExpansion/test/runtests.jl
+++ b/lib/EigenmodeExpansion/test/runtests.jl
@@ -161,4 +161,81 @@ const COUPLER_STACK = LayerStack(
         gdir_ad = sum(g_ad[1] .* dir)
         @test isapprox(gdir_ad, gdir_fd; rtol=5e-2, atol=1e-6)
     end
+
+    @testset "cross-section dedup" begin
+        # uniform (straight) waveguide → every cell's cross-section is identical
+        path = tempname() * ".gds"
+        write_gds(path, coupler_polygons(; gap0=0.6, gap1=0.6))
+        st = Structure(read_gds(path), COUPLER_STACK; transverse_pad=1.5, vertical_pad=1.0)
+        ω = 1 / 1.55
+        grid = simulation_grid(st, 64, 32)
+        cells = build_cells(st; num_cells=4)
+        # all four cells collapse to a single representative
+        reps, gid = dedup_groups(cells)
+        @test length(reps) == 1
+        @test gid == fill(1, 4)
+        @test cross_section_key(cells[1].cross_section) == cross_section_key(cells[3].cross_section)
+        # dedup must not change the device S-matrix (shared vs independent identical solves)
+        r_dd = eme(cells, st.stack.materials, ω, grid; nev=2, dedup=true, k_tol=1e-8)
+        r_nd = eme(cells, st.stack.materials, ω, grid; nev=2, dedup=false, k_tol=1e-8)
+        @test isapprox(power_coupling(r_dd), power_coupling(r_nd); rtol=1e-4)
+        # a tapered device has all-distinct cross-sections → dedup is a no-op
+        path2 = tempname() * ".gds"
+        write_gds(path2, coupler_polygons())                  # gap narrows along x
+        st2 = Structure(read_gds(path2), COUPLER_STACK; transverse_pad=1.5, vertical_pad=1.0)
+        reps2, _ = dedup_groups(build_cells(st2; num_cells=4))
+        @test length(reps2) == 4
+    end
+
+    @testset "cell-to-cell warm start" begin
+        path = tempname() * ".gds"
+        write_gds(path, coupler_polygons())
+        st = Structure(read_gds(path), COUPLER_STACK; transverse_pad=1.5, vertical_pad=1.0)
+        ω = 1 / 1.55
+        grid = simulation_grid(st, 64, 32)
+        cells = build_cells(st; num_cells=3)
+        # warm-starting only seeds the iterations → converged device S-matrix is unchanged
+        r_cold = eme(cells, st.stack.materials, ω, grid; nev=2, warmstart=false, dedup=false, k_tol=1e-9)
+        r_warm = eme(cells, st.stack.materials, ω, grid; nev=2, warmstart=true, dedup=false, k_tol=1e-9)
+        @test isapprox(power_coupling(r_cold), power_coupling(r_warm); rtol=1e-5)
+        @test isapprox(transmission(r_cold.S), transmission(r_warm.S); atol=1e-5)
+    end
+
+    @testset "passivity & nev-convergence diagnostics" begin
+        path = tempname() * ".gds"
+        write_gds(path, coupler_polygons())
+        st = Structure(read_gds(path), COUPLER_STACK; transverse_pad=1.5, vertical_pad=1.0)
+        ω = 1 / 1.55
+        grid = simulation_grid(st, 64, 32)
+        cells = build_cells(st; num_cells=3)
+        r = eme(cells, st.stack.materials, ω, grid; nev=2, k_tol=1e-8)
+        rep = passivity_report(r)
+        @test length(rep.per_interface) == 2
+        @test rep.max_excess ≥ -1e-12
+        @test rep.passive isa Bool
+        # nev sweep: report shapes line up and the first delta is NaN
+        conv = nev_convergence(cells, st.stack.materials, ω, grid; nevs=1:2, k_tol=1e-8)
+        @test conv.nevs == [1, 2]
+        @test length(conv.values) == 2 && all(isfinite, conv.values)
+        @test isnan(conv.deltas[1]) && isfinite(conv.deltas[2])
+        @test length(conv.max_excess) == 2 && all(x -> x ≥ -1e-12, conv.max_excess)
+    end
+
+    @testset "(cell × ω) batch task mapping" begin
+        # Pure mapping logic of the batched deploy/gather (no SLURM needed): a batch
+        # enqueues (representative cell × ω); gather must find the task for each (cell, ω).
+        reps = [1, 3, 5]                    # representative cell indices after dedup
+        ωs = [0.62, 0.64, 0.66]
+        params = [(; cell=c, ω=w) for w in ωs for c in reps]   # cell varies fastest
+        tmap = EigenmodeExpansion._eme_task_map(params)
+        @test length(tmap) == length(params)
+        # task index resolves to the right (cell, ω) entry
+        for (t, p) in enumerate(params)
+            @test EigenmodeExpansion._eme_task_index(tmap, p.cell, p.ω) == t
+        end
+        # ordering: cell fastest within each ω block
+        @test EigenmodeExpansion._eme_task_index(tmap, 1, 0.62) == 1
+        @test EigenmodeExpansion._eme_task_index(tmap, 3, 0.62) == 2
+        @test EigenmodeExpansion._eme_task_index(tmap, 1, 0.64) == 4
+    end
 end

--- a/lib/MaxwellEigenmodes/src/solve.jl
+++ b/lib/MaxwellEigenmodes/src/solve.jl
@@ -182,8 +182,31 @@ cost; see `eig_adjt`. Solver backends: `KrylovKitEigsolve` (native CPU), `DFTK_L
 function solve_k(ω::T,ε⁻¹::AbstractArray{T},grid::Grid{ND,T},solver::AbstractEigensolver;nev=1,
 	max_eigsolves=60,maxiter=100,k_tol=1e-8,eig_tol=1e-8,log=false,kguess=nothing,Hguess=nothing,
 	f_filter=nothing,overwrite=false) where {ND,T<:Real}
-	ms = ModeSolver(k_guess(ω,ε⁻¹), ε⁻¹, grid; nev, maxiter, tol=eig_tol)
+	# `kguess`/`Hguess` are warm starts: an initial |k| for the Newton inversion and an
+	# initial eigenvector basis for the eigensolver. They only seed the iterations — both
+	# converge to the same eigenpair to tolerance — so the returned value (and its adjoint)
+	# is independent of them. Supplying the neighbouring cell/frequency solution cuts the
+	# Newton- and Lanczos-iteration counts (see `solve_cell_modes`' warm-start path).
+	k0 = kguess === nothing ? k_guess(ω,ε⁻¹) : T(first(kguess))
+	ms = ModeSolver(k0, ε⁻¹, grid; nev, maxiter, tol=eig_tol)
+	if Hguess !== nothing
+		_apply_Hguess!(ms.H⃗, Hguess)
+	end
 	solve_k(ms, ω, solver; nev, maxiter, max_eigsolves, k_tol, eig_tol, log, f_filter,)
+end
+
+# Write a warm-start eigenvector basis into `H⃗` (columns = bands), tolerating a single
+# vector, a vector-of-vectors, or a matrix, and a mismatched band count (extra columns
+# keep their random initialisation; missing bands are ignored).
+function _apply_Hguess!(H⃗::AbstractMatrix, Hguess)
+	cols = Hguess isa AbstractMatrix ? eachcol(Hguess) :
+	       (eltype(Hguess) <: Number ? (Hguess,) : Hguess)
+	for (j, h) in enumerate(cols)
+		j ≤ size(H⃗, 2) || break
+		length(h) == size(H⃗, 1) || continue
+		@views H⃗[:, j] .= h
+	end
+	return H⃗
 end
 
 

--- a/lib/MaxwellEigenmodes/src/solvers/krylovkit.jl
+++ b/lib/MaxwellEigenmodes/src/solvers/krylovkit.jl
@@ -36,7 +36,12 @@ end
 KrylovKitEigsolve() = KrylovKitEigsolve(NullLogger())
 
 function solve_ω²(ms::ModeSolver{ND,T},solver::KrylovKitEigsolve;nev=1,eigind=1,maxiter=200,tol=1e-8,log=false,f_filter=nothing) where {ND,T<:Real}
-	evals,evecs,convinfo = eigsolve(x->ms.M̂*x,rand(Complex{T},size(ms.H⃗[:,1])),nev,:SR; maxiter, tol, krylovdim=50) # , verbosity=2)
+	# Start the Krylov expansion from `ms.H⃗[:,1]` (randomly initialised by the ModeSolver
+	# constructor, or overwritten with a warm-start basis by `solve_k`). This makes the
+	# eigensolve reuse a neighbouring solution when warm-started and keeps cold starts
+	# random; the converged eigenpair is unchanged either way.
+	x₀ = iszero(@view ms.H⃗[:,1]) ? rand(Complex{T},size(ms.H⃗[:,1])) : copy(ms.H⃗[:,1])
+	evals,evecs,convinfo = eigsolve(x->ms.M̂*x,x₀,nev,:SR; maxiter, tol, krylovdim=50) # , verbosity=2)
 
 	evals_res = copy(evals[1:nev])
 	evecs_res = [copy(evecs[i]) for i in 1:nev]


### PR DESCRIPTION
## Summary

Scale and certify EME runs on HPC clusters, where the cost is the per-cell cross-section eigensolves and the natural parallelism is the `n_cells × n_ω` grid of independent mode solves.

**Batched deployment (cell × ω)**
- `deploy_eme(setup_file, cells; ω, dedup=true, …)` farms the whole frequency × cell set as one SLURM array job; `ω` may be a vector. Identical cross-sections are enqueued once and every cell maps back to its representative task at gather.
- `gather_eme(batch, cells, materials, ω, grid; …)` reduces per frequency, returning one `EMEResult` per `ω` (single result for scalar `ω`). The legacy `deploy_eme(setup_file, num_cells::Int; …)` form is retained.

**Cross-section de-duplication**
- `cross_section_key` / `dedup_groups` group geometrically identical cells; `eme` solves each unique cross-section once and shares the modal basis. Uniform/repeated stacks collapse to one solve per distinct geometry, with no change to the device S-matrix.

**Cell-to-cell warm starts**
- `solve_k(ω, ε⁻¹, grid, solver)` now honours its `kguess`/`Hguess` warm-start arguments, and the KrylovKit backend seeds its expansion from `ms.H⃗`. `eme(…; warmstart=true)` chains each cell's solution into the next. Warm starts only seed the iterations, so the converged result and adjoint are unchanged.

**Convergence / accuracy diagnostics**
- `nev_convergence` sweeps the modal-basis size and reports objective deltas plus the raw-interface passivity excess; `passivity_report` measures how far each un-enforced interface S-matrix exceeds `|S|≤1`. Driving `max_excess → 0` (raising `nev`) is what makes the AD-friendly `passivity=:none` adjoint match the enforced primal.

## Validation

- EigenmodeExpansion **51/51** tests pass (adds dedup-equivalence, warm-start-equivalence, diagnostics, and (cell×ω) task-mapping testsets).
- MaxwellEigenmodes **36/36** + 3D periodic adjoint **36/36** + Enzyme fwd/rev **4/4** pass (no regression from the warm-start wiring).
- README and example comments updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayn1B3fv797FbNBY2qiSXX)_