### PR TITLE
DielectricSmoothing: cache frequency-independent geometry scaffold (SmoothingPlan)

### DIFF
--- a/lib/DielectricSmoothing/benchmark/benchmarks.jl
+++ b/lib/DielectricSmoothing/benchmark/benchmarks.jl
@@ -96,6 +96,10 @@ backends_kernel = Dict(
 )
 
 SUITE["primal"]["smooth_ε_128x128"] = @benchmarkable smooth_ε($shapes0, $mat_vals0, $minds0, $grid)
+# Geometry cache: build the frequency-independent scaffold once, then apply per-ω.
+plan0 = smoothing_plan(shapes0, minds0, grid)
+SUITE["primal"]["smoothing_plan_build_128x128"] = @benchmarkable smoothing_plan($shapes0, $minds0, $grid)
+SUITE["primal"]["smooth_ε_cached_128x128"] = @benchmarkable smooth_ε($plan0, $mat_vals0)
 SUITE["primal"]["loss"] = @benchmarkable $loss($mat_vals0)
 SUITE["primal"]["loss_geom"] = @benchmarkable $loss_geom($p_geom0)
 SUITE["primal"]["kottke_kernel"] = @benchmarkable $loss_kernel($xk0)
@@ -124,6 +128,19 @@ function run_and_report(suite)
     t_kernel = minimum(results["primal"]["kottke_kernel"]).time
     println("\n=== DielectricSmoothing benchmark summary (128×128 grid) ===")
     println("primal smoothing loss:  $(t_primal/1e6) ms")
+    # geometry cache: full smooth_ε (geometry + material) vs build-once + per-ω apply
+    t_full = minimum(results["primal"]["smooth_ε_128x128"]).time
+    t_build = minimum(results["primal"]["smoothing_plan_build_128x128"]).time
+    t_cached = minimum(results["primal"]["smooth_ε_cached_128x128"]).time
+    println("\n-- geometry cache (frequency sweep) --")
+    println(rpad("full smooth_ε (per ω):", 30), "$(round(t_full/1e6; digits=3)) ms")
+    println(rpad("plan build (once):", 30), "$(round(t_build/1e6; digits=3)) ms")
+    println(rpad("cached apply (per ω):", 30), "$(round(t_cached/1e6; digits=3)) ms   ($(round(t_full/t_cached; digits=1))× faster per ω)")
+    # N-frequency sweep: full = N·t_full ; cached = t_build + N·t_cached
+    for N in (10, 50)
+        spd = (N * t_full) / (t_build + N * t_cached)
+        println(rpad("  $(N)-ω sweep speedup:", 30), "$(round(spd; digits=1))×")
+    end
     for (name, _) in backends_pipeline
         t = minimum(results["gradient(pipeline)"][name]).time
         println(rpad("pipeline gradient $name:", 36), "$(t/1e6) ms   ($(round(t/t_primal; digits=1))× primal)")

--- a/lib/DielectricSmoothing/src/DielectricSmoothing.jl
+++ b/lib/DielectricSmoothing/src/DielectricSmoothing.jl
@@ -32,6 +32,7 @@ include("grid.jl")
 include("shapes.jl")
 include("kottke.jl")
 include("smooth.jl")
+include("smoothing_plan.jl")
 include("geometry.jl")
 
 end # module DielectricSmoothing

--- a/lib/DielectricSmoothing/src/smoothing_plan.jl
+++ b/lib/DielectricSmoothing/src/smoothing_plan.jl
@@ -1,0 +1,136 @@
+# ──────────────────────────────────────────────────────────────────────────────
+#  Frequency-independent smoothing scaffold (geometry cache).
+#
+#  `smooth_ε(shapes, mat_vals, minds, grid)` does two kinds of work per pixel: a
+#  *geometry* part — classify the pixel from its corners, and for an interface pixel
+#  locate the surface (`surfpt_nearby`), integrate the fill fraction (`volfrac`) and
+#  build the interface frame (`normcart`) — and a *material* part — evaluate the
+#  dispersive Kottke kernel `εₑ_∂ωεₑ_∂²ωεₑ` on the two material columns. The geometry
+#  part depends only on `(shapes, grid)`, not on frequency, yet it is redone at every
+#  ω of a sweep (and, in EME, at every ω of every cell).
+#
+#  A `SmoothingPlan` precomputes that geometry scaffold once; `smooth_ε(plan, mat_vals)`
+#  then applies only the AD-friendly Kottke algebra per ω. The result is identical to
+#  `smooth_ε(shapes, mat_vals, minds, grid)` (same operations, same order) and stays
+#  differentiable in `mat_vals` (the per-ω material data) in every backend; geometry is
+#  frozen in the plan, so geometry-*parameter* gradients still use the original `smooth_ε`.
+#
+#  Note on the size of the win: benchmarking shows the geometry scaffold is only a modest
+#  fraction (~10%) of `smooth_ε` — the per-pixel Kottke kernel and the output assembly,
+#  which both paths share, dominate. So caching mainly removes redundant geometry work
+#  across a sweep (and lets the EME (cell × ω) batch reuse one scaffold per cross-section);
+#  the larger smoothing-cost lever is the per-pixel assembly, a separate optimisation.
+# ──────────────────────────────────────────────────────────────────────────────
+
+export SmoothingPlan, smoothing_plan
+
+# Per-pixel kinds.
+const _PLAN_UNIFORM = 0x01      # whole pixel in one material
+const _PLAN_INTERFACE = 0x02    # one interface between two materials (Kottke)
+const _PLAN_MULTI = 0x03        # ≥3 materials meet → naive corner average
+
+"""
+    SmoothingPlan{ND}
+
+Precomputed, frequency-independent geometry scaffold for [`smooth_ε`](@ref) on a fixed
+geometry and grid. Build it once with [`smoothing_plan`](@ref) and apply it per frequency
+with `smooth_ε(plan, mat_vals)`. Pixels are stored in `corners(grid)` order; each carries
+its kind and the geometry data the Kottke kernel needs — for an interface pixel the fill
+fraction `rvol` and interface frame `S`, plus the material-column indices — so applying the
+plan touches no geometry routines.
+"""
+struct SmoothingPlan{ND}
+    gridsize::NTuple{ND,Int}
+    NC::Int                                  # corners per pixel (4 in 2D, 8 in 3D)
+    kind::Vector{UInt8}
+    a::Vector{Int}                           # uniform: material col; interface: col 1; multi: index into `multi`
+    b::Vector{Int}                           # interface: material col 2 (else 0)
+    rvol::Vector{Float64}                    # interface: material-1 fill fraction
+    S::Vector{SMatrix{3,3,Float64,9}}        # interface: normcart frame
+    multi::Vector{Vector{Int}}               # multi pixels: the `NC` corner material cols
+end
+
+Base.size(p::SmoothingPlan) = p.gridsize
+npixels(p::SmoothingPlan) = length(p.kind)
+
+function Base.show(io::IO, p::SmoothingPlan{ND}) where {ND}
+    nu = count(==(_PLAN_UNIFORM), p.kind)
+    ni = count(==(_PLAN_INTERFACE), p.kind)
+    nm = count(==(_PLAN_MULTI), p.kind)
+    print(io, "SmoothingPlan{$ND}(", p.gridsize, ": $nu uniform, $ni interface, $nm multi)")
+end
+
+"""
+    smoothing_plan(shapes, minds, grid) -> SmoothingPlan
+
+Run the frequency-independent geometry pass of [`smooth_ε`](@ref) once: classify every
+pixel and, for interface pixels, compute the surface location, fill fraction and interface
+frame. The returned [`SmoothingPlan`](@ref) is reused across all frequencies (and, in EME,
+all cells sharing the cross-section) via `smooth_ε(plan, mat_vals)`. `shapes`/`minds` are
+the same foreground-ordered shapes and material-column map [`smooth_ε`](@ref) takes.
+"""
+function smoothing_plan(shapes, minds, grid::Grid{ND,TG}) where {ND,TG<:Real}
+    crn = corners(grid)
+    n = length(crn)
+    kind = Vector{UInt8}(undef, n)
+    a = Vector{Int}(undef, n)
+    b = zeros(Int, n)
+    rvol = zeros(Float64, n)
+    Iframe = SMatrix{3,3,Float64}(I)
+    S = fill(Iframe, n)
+    multi = Vector{Int}[]
+    NC = length(first(crn))
+    for (k, crnrs) in enumerate(crn)
+        ps = proc_sinds(corner_sinds(shapes, crnrs))
+        if iszero(ps[2])
+            kind[k] = _PLAN_UNIFORM
+            a[k] = minds[first(ps)]
+        elseif iszero(ps[3])
+            sidx1, sidx2 = ps[1], ps[2]
+            xyz = sum(crnrs) / NC
+            r₀_n⃗ = surfpt_nearby(xyz, shapes[sidx1])
+            kind[k] = _PLAN_INTERFACE
+            a[k] = minds[sidx1]
+            b[k] = minds[sidx2]
+            rvol[k] = volfrac((vxlmin(crnrs), vxlmax(crnrs)), last(r₀_n⃗), first(r₀_n⃗))
+            S[k] = normcart(vec3D(last(r₀_n⃗)))
+        else
+            kind[k] = _PLAN_MULTI
+            push!(multi, Int[minds[i] for i in ps])
+            a[k] = length(multi)
+        end
+    end
+    return SmoothingPlan{ND}(size(grid), NC, kind, a, b, rvol, S, multi)
+end
+
+@non_differentiable smoothing_plan(shapes::Any, minds::Any, grid::Any)
+
+# Per-pixel application of the plan, returning the 27-vector (ε, ∂ωε, ∂²ωε). Mirrors the
+# three branches of `smooth_ε_single`, but with all geometry already resolved in the plan.
+@inline function _apply_plan_single(p::SmoothingPlan, mat_vals, k::Int)
+    kd = p.kind[k]
+    if kd == _PLAN_UNIFORM
+        return mat_vals[:, p.a[k]]
+    elseif kd == _PLAN_INTERFACE
+        return εₑ_∂ωεₑ_∂²ωεₑ(p.rvol[k], p.S[k], mat_vals[:, p.a[k]], mat_vals[:, p.b[k]])
+    else
+        cols = p.multi[p.a[k]]
+        return sum(c -> mat_vals[:, c], cols) / p.NC
+    end
+end
+
+"""
+    smooth_ε(plan::SmoothingPlan, mat_vals) -> Array
+
+Apply a precomputed [`SmoothingPlan`](@ref) to per-frequency material data `mat_vals`
+(the same `(27, n_materials)` column matrix [`smooth_ε`](@ref) takes), returning the
+identical `(3, 3, 3, size(grid)...)` smoothed-dielectric array — but running only the
+Kottke kernel, with no geometry queries. Differentiable in `mat_vals` (forward and reverse)
+just like the direct method, so material/ω gradients flow through unchanged.
+"""
+function smooth_ε(plan::SmoothingPlan, mat_vals)
+    smoothed_vals = mapreduce(vcat, 1:npixels(plan)) do k
+        _apply_plan_single(plan, mat_vals, k)
+    end
+    return reshape(smoothed_vals, (3, 3, 3, plan.gridsize...))
+end

--- a/lib/DielectricSmoothing/test/runtests.jl
+++ b/lib/DielectricSmoothing/test/runtests.jl
@@ -230,4 +230,38 @@ end
         @test DI.gradient(kernel_geom, AutoForwardDiff(), pk0) ≈ gk_ref rtol = 1e-4
         @test DI.gradient(kernel_geom, AutoMooncake(; config=nothing), pk0) ≈ gk_ref rtol = 1e-4
     end
+
+    @testset "smoothing geometry cache (SmoothingPlan)" begin
+        # The plan precomputes the frequency-independent geometry scaffold once; applying it
+        # to per-ω material data must reproduce the direct `smooth_ε` exactly.
+        plan = smoothing_plan(shapes0, minds0, grid)
+        @test plan isa SmoothingPlan{2}
+        @test size(plan) == size(grid)
+        # every pixel is classified into exactly one kind
+        nu = count(==(0x01), plan.kind); ni = count(==(0x02), plan.kind); nm = count(==(0x03), plan.kind)
+        @test nu + ni + nm == prod(size(grid))
+        @test ni > 0                                          # the ridge has interfaces
+
+        sm_direct = smooth_ε(shapes0, mat_vals0, minds0, grid)
+        sm_cached = smooth_ε(plan, mat_vals0)
+        @test sm_cached == sm_direct                          # identical operations → bit-exact
+
+        # Reuse one plan across frequencies: apply at a second ω and match the direct path.
+        ω1 = 1 / 1.31
+        mat_vals1 = hcat(f_ε([ω1]), vcat(vec(Matrix(1.0I, 3, 3)), zeros(18)))
+        @test smooth_ε(plan, mat_vals1) == smooth_ε(shapes0, mat_vals1, minds0, grid)
+
+        # Material-data gradients still flow through the cached apply, and match the direct
+        # path (the cache freezes geometry but preserves AD in the material data).
+        loss_cached = mv -> sum(abs2, smooth_ε(plan, mv))
+        loss_direct = mv -> sum(abs2, smooth_ε(shapes0, mv, minds0, grid))
+        g_ref = FiniteDifferences.grad(central_fdm(3, 1), loss_cached, mat_vals0)[1]
+        for (name, backend) in (("ForwardDiff", AutoForwardDiff()), ("Zygote", AutoZygote()))
+            @testset "$name" begin
+                @test DI.gradient(loss_cached, backend, mat_vals0) ≈ g_ref rtol = 1e-5
+            end
+        end
+        @test DI.gradient(loss_cached, AutoZygote(), mat_vals0) ≈
+              DI.gradient(loss_direct, AutoZygote(), mat_vals0) rtol = 1e-9
+    end
 end


### PR DESCRIPTION
## Summary

Split `smooth_ε`'s per-pixel work into its frequency-independent geometry part (pixel classification + `surfpt_nearby`/`volfrac`/`normcart`) and its per-ω material part (the dispersive Kottke kernel). `smoothing_plan(shapes, minds, grid)` precomputes the geometry scaffold once; `smooth_ε(plan, mat_vals)` then applies only the Kottke algebra per frequency, so a sweep (and, in EME, every cell that shares a cross-section across ω) stops redoing the geometry queries.

- The cached apply reproduces `smooth_ε(shapes, mat_vals, minds, grid)` **bit-for-bit** and stays differentiable in `mat_vals` in every backend; geometry is frozen in the plan, so geometry-parameter gradients keep using the original `smooth_ε`.

## Honest benchmark result

128×128 and 256×256 grids: the geometry scaffold is only **~10%** of `smooth_ε` — the per-pixel Kottke kernel and the output assembly (shared by both paths) dominate — so the per-ω speedup is ~1.1× plus amortising one geometry pass across the sweep. The docstring and benchmark report this. The larger smoothing-cost lever is the per-pixel output assembly (separate follow-up).

## Validation

- New "smoothing geometry cache" testset passes **9/9** (plan-vs-direct bit-exact, multi-ω reuse, ForwardDiff/Zygote material gradients matching FD and the direct path).
- The 2 remaining suite errors are the pre-existing GeometryPrimitives-0.5.0 geometry-parameter-AD limitation (needs the ≥0.6 fork), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayn1B3fv797FbNBY2qiSXX)_