### PR TITLE
EME: plumb threaded=true smoothing through the EME entry points

### DIFF
--- a/examples/eme_adiabatic_coupler.jl
+++ b/examples/eme_adiabatic_coupler.jl
@@ -51,6 +51,8 @@ stack = LayerStack(
 structure = Structure(layout, stack; transverse_pad=2.0, vertical_pad=1.0)
 
 # ── 3. run EME at 1550 nm ────────────────────────────────────────────────────
+# (for large cross-section grids add `threaded=true` to parallelise the per-cell
+#  sub-pixel smoothing across Julia threads — launch with `julia -t N`.)
 λ = 1.55
 ω = 1 / λ
 res = eme_smatrix(structure, ω; nev=2, Nx=128, Ny=64, num_cells=30, k_tol=1e-8)

--- a/examples/eme_coupler_setup.jl
+++ b/examples/eme_coupler_setup.jl
@@ -24,4 +24,6 @@ const NUM_CELLS = parse(Int, get(ENV, "EME_NUM_CELLS", "30"))
 const CELLS = build_cells(STRUCTURE; num_cells=NUM_CELLS)
 const MATS = STACK.materials
 
-make_problem(p) = cell_problem(CELLS[p.cell], MATS, p.ω, GRID)
+# `threaded=true` parallelises the cross-section smoothing across the worker's threads
+# (launch workers with `julia -t N`, e.g. SlurmConfig(cpus_per_task=N, julia_flags=["-t","N"])).
+make_problem(p) = cell_problem(CELLS[p.cell], MATS, p.ω, GRID; threaded=true)

--- a/lib/EigenmodeExpansion/README.md
+++ b/lib/EigenmodeExpansion/README.md
@@ -64,9 +64,9 @@ are marked non-differentiable. `test/runtests.jl` checks forward-mode dielectric
 sensitivities and reverse-mode end-to-end `ε⁻¹` sensitivities against
 `FiniteDifferences.jl`.
 
-## Performance: dedup, warm starts, convergence
+## Performance: dedup, warm starts, threading, convergence
 
-The expensive work is the per-cell eigensolves. Three knobs reduce and certify it:
+The expensive work is the per-cell eigensolves. These knobs reduce and certify it:
 
 - **`dedup=true`** (default of `eme`) solves each *unique* cross-section once and shares
   the modal basis across every cell with identical geometry — uniform/repeated stacks
@@ -77,6 +77,12 @@ The expensive work is the per-cell eigensolves. Three knobs reduce and certify i
   previous cell's solution (`solve_k`'s `kguess`/`Hguess`), cutting iteration counts on
   slowly-varying (adiabatic) devices. It only seeds the solver, so the converged S-matrix
   is unchanged.
+- **`threaded=true`** runs each cell's sub-pixel smoothing across all Julia threads (the
+  `DielectricSmoothing` assembly fills disjoint pixel columns). It threads from every entry
+  point — `eme`, `eme_smatrix`, `solve_cell_modes`, `cell_dielectric`, and the
+  `cell_problem`/`assemble_eme` SLURM payload — and is bit-identical to the serial result.
+  Launch the worker with threads (`julia -t N`; on SLURM, `SlurmConfig(cpus_per_task=N,
+  julia_flags=["-t","N"])`). Worthwhile for large cross-section grids.
 - **`nev_convergence` / `passivity_report`** certify the modal-basis truncation. A
   truncated basis shows up as a non-passive raw interface (`σ > 1`); raise `nev` until
   `passivity_report(res).max_excess → 0`, at which point the (AD-friendly) `passivity=:none`
@@ -100,12 +106,15 @@ grid  = simulation_grid(structure, 128, 64)
 cells = build_cells(structure; num_cells=30)
 ωs    = 1 ./ (1.50:0.01:1.60)
 batch = deploy_eme("examples/eme_coupler_setup.jl", cells;          # dedup'd (cell × ω) tasks
-                   ω=ωs, nev=2, slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/eme"))
+                   ω=ωs, nev=2,
+                   slurm=SlurmConfig(ssh="me@cluster", remote_dir="/scratch/me/eme",
+                                     cpus_per_task=4, julia_flags=["-t","4"]))  # 4 threads/task
 results = gather_eme(batch, cells, structure.stack.materials, ωs, grid; nev=2)   # Vector{EMEResult}
 ```
 
 The setup script's `make_problem(p)` returns the cell-`p.cell` cross-section at `p.ω` (see
-`cell_problem`). The legacy `deploy_eme(setup_file, num_cells::Int; ω, …)` form (one task
-per cell, no dedup) is still available.
+`cell_problem`); call `cell_problem(...; threaded=true)` there to use the worker's threads
+for smoothing. The legacy `deploy_eme(setup_file, num_cells::Int; ω, …)` form (one task per
+cell, no dedup) is still available.
 
 Full documentation: [`docs/eigenmode_expansion.md`](../../docs/eigenmode_expansion.md).

--- a/lib/EigenmodeExpansion/ext/EigenmodeExpansionModeSweepsExt.jl
+++ b/lib/EigenmodeExpansion/ext/EigenmodeExpansionModeSweepsExt.jl
@@ -36,7 +36,7 @@ end
 
 function EigenmodeExpansion.gather_eme(batch::BatchInfo, cells::AbstractVector{Cell},
         materials, ω, grid; dedup::Bool=true, conjugate::Bool=false, reg::Real=1e-9,
-        reciprocity::Bool=true, passivity::Symbol=:invert, wait::Bool=true)
+        reciprocity::Bool=true, passivity::Symbol=:invert, threaded::Bool=false, wait::Bool=true)
     wait && wait_batch(batch)
     n = length(cells)
     reps, _ = dedup ? dedup_groups(cells) : (collect(1:n), nothing)
@@ -53,7 +53,7 @@ function EigenmodeExpansion.gather_eme(batch::BatchInfo, cells::AbstractVector{C
             evecs_per_rep[k] = [collect(ComplexF64.(ev)) for ev in lf.evecs]
         end
         assemble_eme(cells, kmags_per_rep, evecs_per_rep, materials, ωj, grid;
-            conjugate, reg, reciprocity, passivity, dedup)
+            conjugate, reg, reciprocity, passivity, dedup, threaded)
     end
     return ω isa Number ? only(results) : results
 end

--- a/lib/EigenmodeExpansion/src/eme.jl
+++ b/lib/EigenmodeExpansion/src/eme.jl
@@ -38,14 +38,15 @@ the modal basis across all cells with identical geometry (see [`dedup_groups`](@
 a large saving for stacks with uniform/repeated sections, with no effect on the result.
 `warmstart=true` seeds each successive cell's eigensolve from the previous one's solution
 (`kguess`/`Hguess`), cutting Newton/Lanczos iterations on slowly-varying (adiabatic)
-stacks. `kwargs` are forwarded to `solve_k`.
+stacks. `threaded=true` runs each cell's cross-section smoothing across all Julia threads
+(useful for large grids; pair with `julia -t`). `kwargs` are forwarded to `solve_k`.
 """
 function eme(cells::AbstractVector{Cell}, materials, ω, grid,
              solver::AbstractEigensolver=KrylovKitEigsolve();
              nev::Int=2, conjugate::Bool=false, reg::Real=1e-9,
              reciprocity::Bool=true, passivity::Symbol=:invert,
-             dedup::Bool=true, warmstart::Bool=false, kwargs...)
-    modes = _solve_cells(cells, materials, ω, grid, solver; nev, conjugate, dedup, warmstart, kwargs...)
+             dedup::Bool=true, warmstart::Bool=false, threaded::Bool=false, kwargs...)
+    modes = _solve_cells(cells, materials, ω, grid, solver; nev, conjugate, dedup, warmstart, threaded, kwargs...)
     S = _assemble(modes, [c.length for c in cells]; conjugate, reg, reciprocity, passivity)
     T = typeof(float(ω))
     return EMEResult{T}(S, modes, [c.length for c in cells], T(ω))
@@ -55,14 +56,15 @@ end
 # (optionally) warm-starting each unique solve from the previous one. Returns one
 # `Modes` per cell; cells in the same dedup group share the *same* `Modes` object.
 function _solve_cells(cells::AbstractVector{Cell}, materials, ω, grid, solver;
-                      nev::Int, conjugate::Bool, dedup::Bool, warmstart::Bool, kwargs...)
+                      nev::Int, conjugate::Bool, dedup::Bool, warmstart::Bool,
+                      threaded::Bool=false, kwargs...)
     reps, gid = dedup ? dedup_groups(cells) : (collect(eachindex(cells)), collect(eachindex(cells)))
     prev_k = Ref{Any}(nothing)
     prev_H = Ref{Any}(nothing)
     rep_modes = map(reps) do ci
         kg, hg = warmstart ? (prev_k[], prev_H[]) : (nothing, nothing)
         kmags, evecs, ε⁻¹, ∂ε_∂ω = _cell_raw_solve(cells[ci], materials, ω, grid, solver;
-                                                    nev, kguess=kg, Hguess=hg, kwargs...)
+                                                    nev, kguess=kg, Hguess=hg, threaded, kwargs...)
         if warmstart
             ChainRulesCore.ignore_derivatives() do
                 prev_k[] = copy(kmags); prev_H[] = [copy(ev) for ev in evecs]
@@ -100,10 +102,11 @@ end
 
 """
     eme_smatrix(structure, ω; nev=2, Nx=128, Ny=96, num_cells=20,
-                solver=KrylovKitEigsolve(), kwargs...) -> EMEResult
+                solver=KrylovKitEigsolve(), threaded=false, kwargs...) -> EMEResult
 
 Convenience entry point: build the simulation grid and cells from a
-[`Structure`](@ref), then run [`eme`](@ref).
+[`Structure`](@ref), then run [`eme`](@ref). Extra keywords (including `threaded` to
+parallelise the per-cell smoothing, `dedup`, `warmstart`) are forwarded to [`eme`](@ref).
 """
 function eme_smatrix(st::Structure, ω; nev::Int=2, Nx::Int=128, Ny::Int=96,
                      num_cells::Int=20, solver::AbstractEigensolver=KrylovKitEigsolve(),

--- a/lib/EigenmodeExpansion/src/modes.jl
+++ b/lib/EigenmodeExpansion/src/modes.jl
@@ -61,16 +61,18 @@ function ChainRulesCore.rrule(::Type{Mode}, ω, k, neff, E, H, δA)
 end
 
 """
-    cell_dielectric(cross_section, materials, ω, grid) -> (ε⁻¹, ∂ε_∂ω)
+    cell_dielectric(cross_section, materials, ω, grid; threaded=false) -> (ε⁻¹, ∂ε_∂ω)
 
 Smooth a [`CrossSection`](@ref) onto `grid` at frequency `ω`, returning the
 inverse dielectric tensor field and its frequency derivative (the inputs the
 eigensolver and group-index machinery expect). Differentiable in `ω` and in any
-geometry parameters that flow through the cross-section shapes.
+geometry parameters that flow through the cross-section shapes. `threaded=true`
+runs the sub-pixel smoothing across all Julia threads (worthwhile for large grids;
+pair with `julia -t`).
 """
-function cell_dielectric(cs::CrossSection, materials, ω, grid)
+function cell_dielectric(cs::CrossSection, materials, ω, grid; threaded::Bool=false)
     mat_vals = _mat_vals(materials, ω)
-    sm = smooth_ε(Tuple(cs.shapes), mat_vals, Tuple(cs.minds), grid)
+    sm = smooth_ε(Tuple(cs.shapes), mat_vals, Tuple(cs.minds), grid; threaded)
     ε⁻¹ = sliceinv_3x3(copy(selectdim(sm, 3, 1)))
     ∂ε_∂ω = copy(selectdim(sm, 3, 2))
     return ε⁻¹, ∂ε_∂ω
@@ -123,25 +125,27 @@ end
 # `(kmags, evecs)` of one cell can warm-start the next (`kguess`/`Hguess`). The warm-start
 # seeds are forwarded as `solve_k` keyword arguments and so do not participate in AD.
 function _cell_raw_solve(cell::Cell, materials, ω, grid, solver::AbstractEigensolver;
-                         nev::Int=2, kguess=nothing, Hguess=nothing, kwargs...)
-    ε⁻¹, ∂ε_∂ω = cell_dielectric(cell.cross_section, materials, ω, grid)
+                         nev::Int=2, kguess=nothing, Hguess=nothing, threaded::Bool=false, kwargs...)
+    ε⁻¹, ∂ε_∂ω = cell_dielectric(cell.cross_section, materials, ω, grid; threaded)
     kmags, evecs = solve_k(ω, ε⁻¹, grid, solver; nev, kguess, Hguess, kwargs...)
     return kmags, evecs, ε⁻¹, ∂ε_∂ω
 end
 
 """
     solve_cell_modes(cell, materials, ω, grid, solver; nev=2, conjugate=false,
-                     kguess=nothing, Hguess=nothing, kwargs...) -> Modes
+                     kguess=nothing, Hguess=nothing, threaded=false, kwargs...) -> Modes
 
 Solve the `nev` lowest modes of `cell`'s cross-section. `kwargs` are forwarded to
 `MaxwellEigenmodes.solve_k` (e.g. `k_tol`, `maxiter`). Optional `kguess` (an initial `|k|`)
 and `Hguess` (an initial transverse-`H` eigenvector basis, e.g. the previous cell's
 `evecs`) warm-start the Newton/eigensolver iterations without changing the converged
-result. The returned modes are the modal basis for that cell in the EME expansion.
+result. `threaded=true` runs the cross-section smoothing across all Julia threads. The
+returned modes are the modal basis for that cell in the EME expansion.
 """
 function solve_cell_modes(cell::Cell, materials, ω, grid, solver::AbstractEigensolver=KrylovKitEigsolve();
-                          nev::Int=2, conjugate::Bool=false, kguess=nothing, Hguess=nothing, kwargs...)
-    kmags, evecs, ε⁻¹, ∂ε_∂ω = _cell_raw_solve(cell, materials, ω, grid, solver; nev, kguess, Hguess, kwargs...)
+                          nev::Int=2, conjugate::Bool=false, kguess=nothing, Hguess=nothing,
+                          threaded::Bool=false, kwargs...)
+    kmags, evecs, ε⁻¹, ∂ε_∂ω = _cell_raw_solve(cell, materials, ω, grid, solver; nev, kguess, Hguess, threaded, kwargs...)
     return [build_mode(ω, kmags[i], evecs[i], ε⁻¹, ∂ε_∂ω, grid; conjugate) for i in 1:nev]
 end
 

--- a/lib/EigenmodeExpansion/src/sweeps.jl
+++ b/lib/EigenmodeExpansion/src/sweeps.jl
@@ -59,20 +59,22 @@ _eme_task_index(d::AbstractDict, cell::Int, ω::Real; atol::Float64=1e-12) =
     d[(cell, _ωkey(ω; atol))]
 
 """
-    cell_problem(cell, materials, ω, grid) -> NamedTuple
+    cell_problem(cell, materials, ω, grid; threaded=false) -> NamedTuple
 
 Build the ModeSweeps `make_problem`-style payload `(; ε⁻¹, ∂ε_∂ω, ∂²ε_∂ω², grid)`
 for a single EME [`Cell`](@ref). A ModeSweeps setup script can solve one cell per
 SLURM array task with
 
-    make_problem(p) = cell_problem(CELLS[p.cell], MATERIALS, p.ω, GRID)
+    make_problem(p) = cell_problem(CELLS[p.cell], MATERIALS, p.ω, GRID; threaded=true)
 
 so an entire EME stack's mode solves are deployed as one batch (and swept over ω
-or geometry alongside the cell index).
+or geometry alongside the cell index). Set `threaded=true` (with the worker launched
+under `julia -t N`, e.g. `SlurmConfig(cpus_per_task=N, julia_flags=["-t","N"])`) to
+thread the cross-section smoothing within each task.
 """
-function cell_problem(cell::Cell, materials, ω, grid)
+function cell_problem(cell::Cell, materials, ω, grid; threaded::Bool=false)
     mat_vals = _mat_vals(materials, ω)
-    sm = smooth_ε(Tuple(cell.cross_section.shapes), mat_vals, Tuple(cell.cross_section.minds), grid)
+    sm = smooth_ε(Tuple(cell.cross_section.shapes), mat_vals, Tuple(cell.cross_section.minds), grid; threaded)
     return (;
         ε⁻¹=sliceinv_3x3(copy(selectdim(sm, 3, 1))),
         ∂ε_∂ω=copy(selectdim(sm, 3, 2)),
@@ -83,22 +85,24 @@ end
 
 """
     assemble_eme(cells, kmags_per_cell, evecs_per_cell, materials, ω, grid;
-                 conjugate=false, reg=1e-9, reciprocity=true) -> EMEResult
+                 conjugate=false, reg=1e-9, reciprocity=true, threaded=false) -> EMEResult
 
 Re-assemble a device S-matrix from per-cell eigensolutions (`kmags`/`evecs`,
 e.g. gathered from a ModeSweeps batch). Mode fields are reconstructed locally
 (cheap; no eigensolve) and the interface/propagation S-matrices are cascaded as
-in [`eme`](@ref).
+in [`eme`](@ref). `threaded=true` threads the cross-section smoothing used to
+rebuild each representative cell's dielectric.
 """
 function assemble_eme(cells::AbstractVector{Cell}, kmags_per_cell, evecs_per_cell,
                       materials, ω, grid; conjugate::Bool=false, reg::Real=1e-9,
-                      reciprocity::Bool=true, passivity::Symbol=:invert, dedup::Bool=true)
+                      reciprocity::Bool=true, passivity::Symbol=:invert, dedup::Bool=true,
+                      threaded::Bool=false)
     n = length(cells)
     reps, gid = dedup ? dedup_groups(cells) : (collect(1:n), collect(1:n))
     # reconstruct each unique cross-section's modes once, then share across its group
     rep_modes = map(eachindex(reps)) do k
         ci = reps[k]
-        ε⁻¹, ∂ε_∂ω = cell_dielectric(cells[ci].cross_section, materials, ω, grid)
+        ε⁻¹, ∂ε_∂ω = cell_dielectric(cells[ci].cross_section, materials, ω, grid; threaded)
         [build_mode(ω, kmags_per_cell[k][j], evecs_per_cell[k][j], ε⁻¹, ∂ε_∂ω, grid; conjugate)
          for j in eachindex(kmags_per_cell[k])]
     end

--- a/lib/EigenmodeExpansion/test/runtests.jl
+++ b/lib/EigenmodeExpansion/test/runtests.jl
@@ -238,4 +238,29 @@ const COUPLER_STACK = LayerStack(
         @test EigenmodeExpansion._eme_task_index(tmap, 3, 0.62) == 2
         @test EigenmodeExpansion._eme_task_index(tmap, 1, 0.64) == 4
     end
+
+    @testset "threaded smoothing passthrough" begin
+        # `threaded=true` reaches smooth_ε from the EME entry points and is bit-identical
+        # to the serial smoothing (the threaded fill writes disjoint pixel columns).
+        path = tempname() * ".gds"
+        write_gds(path, coupler_polygons())
+        st = Structure(read_gds(path), COUPLER_STACK; transverse_pad=1.5, vertical_pad=1.0)
+        ω = 1 / 1.55
+        grid = simulation_grid(st, 64, 32)
+        cells = build_cells(st; num_cells=3)
+        mats = st.stack.materials
+        # cell_dielectric: threaded == serial
+        e1, d1 = cell_dielectric(cells[1].cross_section, mats, ω, grid; threaded=false)
+        e2, d2 = cell_dielectric(cells[1].cross_section, mats, ω, grid; threaded=true)
+        @test e1 == e2 && d1 == d2
+        # cell_problem (ModeSweeps worker payload): threaded == serial
+        p1 = cell_problem(cells[1], mats, ω, grid; threaded=false)
+        p2 = cell_problem(cells[1], mats, ω, grid; threaded=true)
+        @test p1.ε⁻¹ == p2.ε⁻¹ && p1.∂ε_∂ω == p2.∂ε_∂ω && p1.∂²ε_∂ω² == p2.∂²ε_∂ω²
+        # full eme: threaded passes through and leaves the device S-matrix unchanged
+        rS = eme(cells, mats, ω, grid; nev=2, threaded=false, k_tol=1e-8)
+        rT = eme(cells, mats, ω, grid; nev=2, threaded=true, k_tol=1e-8)
+        @test power_coupling(rT) ≈ power_coupling(rS) rtol = 1e-6
+        @test transmission(rT.S) ≈ transmission(rS.S) atol = 1e-6
+    end
 end


### PR DESCRIPTION
## Summary

Expose the `DielectricSmoothing` threaded assembly (`smooth_ε(...; threaded=true)`, merged in #43) from every EME entry point, so the per-cell cross-section smoothing parallelises on a compute node:

- `cell_dielectric`, `solve_cell_modes`, `_cell_raw_solve`, `_solve_cells`, `eme`, and `eme_smatrix` take/forward `threaded` — kept as an **explicit keyword** so it reaches `smooth_ε` but is *not* forwarded into `solve_k`.
- `cell_problem` (the ModeSweeps worker payload) and `assemble_eme` take `threaded`, and the ModeSweeps `gather_eme` forwards it — so a SLURM batch threads smoothing within each task when workers are launched with `julia -t N` (`SlurmConfig(cpus_per_task=N, julia_flags=["-t","N"])`).

Threading only changes how the (disjoint) pixels are filled, so results are **bit-identical** to the serial path. Default remains `threaded=false`, so existing call sites are unchanged.

## Validation

- New "threaded smoothing passthrough" testset: `cell_dielectric`/`cell_problem` threaded≡serial (bit-exact, incl. `∂²ε/∂ω²`), and a full `eme` run is unchanged with `threaded=true`.
- EigenmodeExpansion suite passes **55/55** (run with 4 threads).
- README performance section, SLURM example, and the coupler setup/example updated to show the threaded worker config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayn1B3fv797FbNBY2qiSXX)_