### PR TITLE
examples: true EME transmission overlay + shared a-la-carte settings

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,167 @@
+# OptiMode.jl examples
+
+Every example is a standalone script: `julia --project=. examples/<script>.jl` from the repo
+root. Most save plots to `examples/paper_reproduction_output/` (created on first run,
+gitignored) and print the path at the end.
+
+## The settings system
+
+The paper-reproduction, EME, and AD-designer examples (everything that `include`s
+`paper_reproductions_common.jl`, `eme_reproductions_common.jl`, or `designer_common.jl` — see
+the catalog below) share one **a-la-carte settings** module, `example_settings.jl`, so accuracy
+and run-mode knobs work the same way everywhere instead of being hardcoded per script.
+
+Every setting can be given three equivalent ways, resolved with this precedence (**highest
+wins**):
+
+```
+command-line flag  >  environment variable  >  script's own example_settings(...) keyword  >  built-in default
+```
+
+The script's own keyword is its pre-validated, tuned default (e.g. a dispersion sweep that's
+known to need 13 points to resolve a feature) — CLI/ENV let you override it for a quick
+accuracy/speed experiment without editing source.
+
+| Setting             | CLI flag                  | Environment variable        | Default | Meaning |
+|----------------------|----------------------------|------------------------------|---------|---------|
+| `resolution_scale`   | `--resolution-scale=X`     | `OPTIMODE_RESOLUTION_SCALE`  | `1.0`   | Multiplies the grid point count at fixed physical domain size (finer/coarser mesh). |
+| `domain_scale`       | `--domain-scale=X`         | `OPTIMODE_DOMAIN_SCALE`      | `1.0`   | Multiplies the physical domain size (how far the simulation boundary sits from the core); point count scales with it so resolution (points/µm) is unchanged. |
+| `n_freqs`            | `--n-freqs=N`              | `OPTIMODE_N_FREQS`           | varies  | Number of wavelengths (or other swept parameter) in a *mode-solve* sweep — the expensive, per-point-eigensolve knob (dispersion sweeps, QPM tuning, supermode crossings, designer validation sweeps). |
+| `n_dense`            | `--n-dense=N`              | `OPTIMODE_N_DENSE`           | varies  | Number of points in a *cheap, closed-form* dense curve (interpolated transmission, analytic gain/QPM-mismatch spectra) — free to make large; only affects plot smoothness. |
+| `n_eme_freqs`        | `--n-eme-freqs=N`          | `OPTIMODE_N_EME_FREQS`       | `15`    | Number of wavelengths for a genuinely EME-solved (`eme`/`power_coupling`) dense transmission overlay, where an example provides one (currently `tfln_combiner_kwolek2026.jl`). |
+| `n_cells`            | `--n-cells=N`              | `OPTIMODE_N_CELLS`           | `6`     | Number of cells in an EME cascade. |
+| `run_mode`           | `--run-mode=local\|slurm`  | `OPTIMODE_RUN_MODE`          | `local` | See [Local vs. SLURM](#local-vs-slurm) below. |
+| `slurm`              | *(keyword only)*           | —                            | `nothing` | A `ModeSweeps.SlurmConfig`; only settable as an `example_settings(slurm=...)` keyword (it has too many sub-fields for a single flag/env var) — see `remote_mode_solve.jl`. |
+
+`--help` / `-h` on any of these scripts prints the same reference table and exits.
+
+Every script prints its resolved settings on startup, e.g.:
+
+```
+== settings: ExampleSettings(resolution_scale=1.0, domain_scale=1.0, n_freqs=7, n_dense=400, n_eme_freqs=15, n_cells=6, run_mode=local) ==
+```
+
+### Usage examples
+
+```sh
+# Run an example at its default (validated) settings
+julia --project=. examples/tantala_gvd_black2021.jl
+
+# Finer grid, more dispersion-sweep points, via CLI flags
+julia --project=. examples/tantala_gvd_black2021.jl --resolution-scale=2 --n-freqs=25
+
+# The same, via environment variables (handy for batch scripts / CI)
+OPTIMODE_RESOLUTION_SCALE=2 OPTIMODE_N_FREQS=25 julia --project=. examples/tantala_gvd_black2021.jl
+
+# Push the simulation boundary further from the core (fixed resolution) — check for
+# boundary-truncation artifacts on a leaky/weakly-confined mode
+julia --project=. examples/si3n4_cw_opa_riemensberger2022.jl --domain-scale=1.5
+
+# Cheaper/faster smoke-test run (coarse grid, few points) — good for CI or a quick check
+julia --project=. examples/dichroic_filter_magden2018.jl --resolution-scale=0.5 --n-freqs=3 --n-dense=20
+
+# Deeper EME overlay + finer grid together
+julia --project=. examples/tfln_combiner_kwolek2026.jl --n-eme-freqs=30 --resolution-scale=1.5
+
+# More EME cascade cells (validation step)
+julia --project=. examples/tfln_combiner_kwolek2026.jl --n-cells=12
+
+# List every available setting for a script
+julia --project=. examples/tantala_gvd_black2021.jl --help
+```
+
+A script can also set its own defaults in code — this is what each example does for its
+pre-tuned values (CLI/ENV still override them):
+
+```julia
+cfg = example_settings(n_freqs=13, n_dense=401)   # this script's validated defaults
+grid = mk_grid(cfg, 5.0, 4.0, 128, 100)             # Grid(Lx0, Ly0, nx0, ny0) at scale=1
+```
+
+### Local vs. SLURM
+
+`run_mode` is resolved consistently everywhere, but only the dedicated ModeSweeps-based
+examples *act* on `:slurm` today:
+
+- `remote_mode_solve.jl`, `remote_adjoint_optimization.jl`, `tfln_ppln_geometry_sweep_deploy.jl`
+  already accept a `ModeSweeps.SlurmConfig` and a `backend` (`:local`/`:slurm`) and dispatch
+  frequency/geometry sweeps to a cluster over ssh+rsync (see `SlurmConfig`'s docstring and
+  `ridge_wg_setup.jl` for the worker-side "setup script" convention these use).
+- The paper-reproduction / EME / AD-designer family (everything using `example_settings`) runs
+  its mode-solve sweeps inline, in-process — they're a handful of points (`n_freqs`, typically
+  3–15), fast enough on a workstation that cluster dispatch isn't needed. Passing
+  `--run-mode=slurm` to one of these is accepted and printed in the resolved settings, but the
+  script still runs locally; for cluster-scale sweeps of this physics, use the dedicated
+  ModeSweeps entry points above (or increase `n_freqs`/`resolution_scale` and let it run
+  longer locally).
+
+## `tfln_combiner_kwolek2026.jl`: two ways to get the dense transmission curve
+
+This example's combiner-response plot overlays two independently-computed curves so you can see
+they agree:
+
+1. **Analytic, interpolated** (`T_cross(λ)=sin²(πLΔn(λ)/λ)`, `cfg.n_dense` points): cheap, smooth,
+   but `Δn(λ)` is linearly interpolated from the sparse (`cfg.n_freqs`-point) supermode dispersion
+   sweep — it does *not* re-solve modes at every plotted wavelength.
+2. **True EME** (`directional_coupler_transmission`, `cfg.n_eme_freqs` points): OptiMode's actual
+   `eme` scattering matrix, solved fresh at each plotted wavelength (no interpolation), projected
+   onto the physical bar/cross ports via `port_transmission`.
+
+Both are exact for a *uniform* coupler in the sense that (1) is just an interpolated evaluation
+of the same closed form (2) computes exactly — but (2) is the one that re-solves the modes, so
+it's the ground truth wherever (1)'s interpolation is coarse. Increase `--n-eme-freqs` to shrink
+the gap between them.
+
+## Example catalog
+
+### Paper reproductions — χ²/χ³ dispersion + OPA (share `paper_reproductions_common.jl`)
+- `tantala_gvd_black2021.jl` — Ta₂O₅ GVD engineering + Kerr FWM gain (Black et al., Opt. Lett. 2021).
+- `si3n4_cw_opa_riemensberger2022.jl` — Si₃N₄ dispersion + continuous-wave Kerr OPA (Riemensberger et al., Nature 2022).
+- `pplt_allband_opa_kuznetsov2026.jl` — PPLT cascaded-χ² all-band OPA (Kuznetsov et al., arXiv:2605.22704).
+- `ppln_reconfigurable_opa_han2026.jl` — x-cut TFLN χ² QPM OPA (Han et al., arXiv:2602.00246).
+- `ppln_thermal_tuning_han2026.jl` — electro-thermal QPM tuning companion to the above.
+
+### EME reproductions + AD designers (share `eme_reproductions_common.jl` / `designer_common.jl`)
+- `dichroic_filter_magden2018.jl` — Si SOI thickness-contrast dichroic filter (Magden et al., Nat. Commun. 2018).
+- `tfln_combiner_kwolek2026.jl` — TFLN >1-octave wavelength combiner (Kwolek et al., arXiv:2603.27034); see the dense-transmission note above.
+- `designer_qpm_mgoln_1310.jl` — AD-optimized χ² SHG QPM design, MgO:LiNbO₃ rib, new 1310→655 nm target.
+- `designer_dispersion_tantala_1p3um.jl` — AD-optimized zero-GVD design, Ta₂O₅ air-clad core, new 1.30 µm target.
+- `designer_dichroic_si3n4.jl` — AD-optimized EME dichroic cutoff, Si₃N₄ thickness-contrast coupler, new 1.00 µm target.
+
+### Dispersion-engineered PPLN (Jankowski et al., Optica 2020)
+- `tfln_ppln_jankowski2020.jl` / `tfln_ppln_jankowski2020_common.jl` — dispersion-engineered nanophotonic PPLN reproduction.
+- `tfln_ppln_geometry_sweep_setup.jl` / `tfln_ppln_geometry_sweep_deploy.jl` — the converged geometry-map version of the above, deployed as a ModeSweeps/SLURM batch.
+
+### Adjoint / automatic differentiation
+- `bragg_waveguide_period_adjoint.jl` — 3D periodic (Bragg) waveguide mode solving + adjoint sensitivity to the period.
+- `tfln_bragg_waveguide_dispersion_adjoint.jl` — dispersion + adjoint sensitivities of a width-modulated TFLN Bragg waveguide.
+- `tfln_shg_dispersion.jl` — forward SHG phase-matching dispersion calculation for TFLN.
+- `tfln_shg_temperature_angle_ad.jl` — forward/reverse AD of SHG phase matching w.r.t. temperature and crystal orientation.
+- `ad_backend_benchmarks.jl` — timing comparison of the AD backends (ForwardDiff/Zygote/Enzyme/Mooncake/hybrid).
+
+### Remote / SLURM deployment (ModeSweeps)
+- `remote_mode_solve.jl` — deploy/monitor/gather mode-solver sweeps on a SLURM cluster (or `:local`).
+- `remote_adjoint_optimization.jl` — SLURM-managed automatic differentiation of the mode solver.
+- `ridge_wg_setup.jl`, `kerr_power_sweep_setup.jl`, `eme_coupler_setup.jl` — ModeSweeps worker "setup scripts" used by the above.
+
+### Perturbation theory (first-order index/loss corrections)
+- `perturbation_kerr_spm.jl` — χ³ self-phase modulation.
+- `perturbation_xpm.jl` — χ³ cross-phase modulation.
+- `perturbation_tpa_loss.jl` — two-photon-absorption loss.
+- `perturbation_cascaded_chi2.jl` — cascaded-χ² effective Kerr nonlinearity.
+- `perturbation_shg_efficiency.jl` — χ² SHG normalized efficiency (TFLN).
+- `perturbation_thermo_optic.jl` — thermo-optic tuning.
+- `perturbation_substrate_leakage.jl` — substrate-leakage loss.
+- `perturbation_surface_roughness_loss.jl` — sidewall-roughness scattering loss (Payne–Lacey).
+- `perturbation_userdefined_index.jl` — arbitrary user-specified Δn(x,y) perturbation.
+
+### Other mode-solver demos
+- `kerr_si3n4_waveguide.jl` — Kerr power-dependent mode solves for a Si₃N₄ waveguide.
+- `hermite_gaussian_mode_labeling.jl` — Hermite–Gaussian mode classification vs. node counting.
+- `forced_grid_convergence.jl` — finite-grid convergence study for a Si₃N₄ ridge.
+- `eme_adiabatic_coupler.jl` — EME of an adiabatic coupler driven from a GDSFactory GDS layout.
+- `material_fitting_sellmeier.jl` — fitting Sellmeier material models with `MaterialFitting`.
+
+These groups don't yet use the `example_settings` module (several have their own established
+sweep/deploy conventions, e.g. the ModeSweeps setup-script pattern) — see each script's header
+for its own configuration knobs.

--- a/examples/designer_dichroic_si3n4.jl
+++ b/examples/designer_dichroic_si3n4.jl
@@ -12,18 +12,23 @@
 # Zygote(adjoint eigensolve) gradient, driving Adam. The optimum places β_A = β_B exactly at
 # the 1000-nm target.
 #
+# Settings (see examples/README.md): --n-freqs (post-optimization crossing sweep, default 11),
+# --resolution-scale / --domain-scale (grid — kept small by default for fast AD).
+#
 # Run:  julia --project=. examples/designer_dichroic_si3n4.jl   (needs CairoMakie)
+#       julia --project=. examples/designer_dichroic_si3n4.jl --resolution-scale=2
 
 include(joinpath(@__DIR__, "designer_common.jl"))
 using CairoMakie
 
+cfg = example_settings(n_freqs=11)
 solver = KrylovKitEigsolve()
 λC_target = 1.00                              # NEW cutoff target (µm)
 tA, tB = 0.40, 0.20                           # WGA thick / WGB thin Si₃N₄ (thickness-contrast)
 wB = 1.10                                      # WGB fixed width (thin, wide)
 mats = [Si₃N₄, SiO₂]
 mv = matvals_builder(mats; air=false)         # Si₃N₄ cores buried in SiO₂
-grid = Grid(5.0, 3.0, 40, 30)
+grid = mk_grid(cfg, 5.0, 3.0, 40, 30)
 
 wgA(w) = (MaterialShape(Cuboid([0.0, 0.0], [w[1], tA], [1.0 0.0; 0.0 1.0]), 1),)
 wgB     = (MaterialShape(Cuboid([0.0, 0.0], [wB, tB], [1.0 0.0; 0.0 1.0]), 1),)
@@ -49,7 +54,7 @@ wA★ = res.p[1]
 @printf("optimized w_A=%.3f µm: n_A(λ_C)=%.4f  (n_B=%.4f)\n", wA★, nA_of([wA★], λC_target), nB_target)
 
 # --- dispersion crossing before / after + cutoff ---------------------------------------
-λs = collect(range(0.80, 1.30; length=11))
+λs = collect(range(0.80, 1.30; length=cfg.n_freqs))
 nB = [nB_of(λ) for λ in λs]
 nA0 = [nA_of(w0, λ) for λ in λs]
 nA★ = [nA_of([wA★], λ) for λ in λs]

--- a/examples/designer_dispersion_tantala_1p3um.jl
+++ b/examples/designer_dispersion_tantala_1p3um.jl
@@ -12,16 +12,21 @@
 # n_g) and finite-differences only the scalar ω-derivative (β₂ = ∂n_g/∂ω), per Gray, West & Ram
 # (2024). Adam then drives β₂ → 0 at 1.3 µm and the ZDW onto the target.
 #
+# Settings (see examples/README.md): --n-freqs (post-optimization β₂(λ) sweep, default 9),
+# --resolution-scale / --domain-scale (grid — kept small by default for fast AD).
+#
 # Run:  julia --project=. examples/designer_dispersion_tantala_1p3um.jl   (needs CairoMakie)
+#       julia --project=. examples/designer_dispersion_tantala_1p3um.jl --resolution-scale=2
 
 include(joinpath(@__DIR__, "designer_common.jl"))
 using CairoMakie
 
+cfg = example_settings(n_freqs=9)
 solver = KrylovKitEigsolve()
 λ0 = 1.30                                      # NEW target: zero-GVD at 1.30 µm
 mats = [Ta₂O₅, SiO₂]
 mv = matvals_builder(mats; air=true)           # tantala core on SiO₂ substrate, air-clad
-grid = Grid(5.0, 4.0, 40, 32)
+grid = mk_grid(cfg, 5.0, 4.0, 40, 32)
 # tantala core (w, h) sitting on a SiO₂ substrate (core bottom at y=0), air top + sides
 geomfn(p) = (MaterialShape(Cuboid([0.0, p[2]/2], [p[1], p[2]], [1.0 0.0; 0.0 1.0]), 1),
              MaterialShape(Cuboid([0.0, -1.5], [100.0, 3.0], [1.0 0.0; 0.0 1.0]), 2))
@@ -43,7 +48,7 @@ p★ = res.p
 @printf("optimized (w,h)=(%.3f,%.3f) µm: β₂=%+.1f fs²/mm (target 0)\n", p★[1], p★[2], β2_grad(p★)[1])
 
 # --- β₂(λ) before / after: the ZDW moves to the target ---------------------------------
-λs = collect(range(1.0, 1.7; length=9))
+λs = collect(range(1.0, 1.7; length=cfg.n_freqs))
 disp(p) = [gvd_value_grad(geomfn, mv, minds, grid, p, 1/λ, solver)[1] for λ in λs]
 β2_0 = disp(p0); β2_★ = disp(p★)
 zdw(b) = (for i in 1:length(λs)-1; sign(b[i]) != sign(b[i+1]) && return λs[i]-b[i]*(λs[i+1]-λs[i])/(b[i+1]-b[i]); end; NaN)

--- a/examples/designer_qpm_mgoln_1310.jl
+++ b/examples/designer_qpm_mgoln_1310.jl
@@ -12,12 +12,17 @@
 # dΔn/dw = dn_SH/dw − dn_FF/dw is the hybrid ForwardDiff(geometry)∘Zygote(adjoint eigensolve)
 # gradient (designer_common.jl), driving an Adam optimizer. No finite-difference geometry sweep.
 #
+# Settings (see examples/README.md): --n-freqs (post-optimization Δn(w) landscape sweep,
+# default 15), --resolution-scale / --domain-scale (grid — kept small by default for fast AD).
+#
 # Run:  julia --project=. examples/designer_qpm_mgoln_1310.jl   (needs CairoMakie)
+#       julia --project=. examples/designer_qpm_mgoln_1310.jl --resolution-scale=2
 
 include(joinpath(@__DIR__, "designer_common.jl"))
 using OptiMode.MaterialDispersion: MgO_LiNbO₃
 using CairoMakie
 
+cfg = example_settings(n_freqs=15)
 solver = KrylovKitEigsolve()
 λF = 1.31; λS = λF/2                          # NEW target: 1310 nm FH → 655 nm SH
 Λ_target = 4.0                                # fabrication-preferred poling period (µm)
@@ -26,7 +31,7 @@ film, slab, etch = 0.70, 0.30, 0.40          # 700-nm MgO:LiNbO₃, 400-nm etch 
 
 mats = [MgO_LiNbO₃, SiO₂]
 mv = matvals_builder(mats; air=true)         # MgO:LiNbO₃ core, SiO₂ box, air background
-grid = Grid(6.0, 3.6, 40, 30)                # small grid → fast AD optimization
+grid = mk_grid(cfg, 6.0, 3.6, 40, 30)        # small grid by default → fast AD optimization
 # rib of top width w[1] on the unetched slab, over a SiO₂ substrate; air above
 geomfn(w) = (
     MaterialShape(Cuboid([0.0, slab + etch/2], [w[1], etch], [1.0 0.0; 0.0 1.0]), 1),
@@ -56,7 +61,7 @@ w★ = res.p[1]
 @printf("optimized w=%.3f µm: Δn=%.4f  → Λ=%.3f µm (target %.1f)\n", w★, Δn★, Λ★, Λ_target)
 
 # --- Δn(w) landscape + poling period, marking start/optimum ------------------------------
-ws = collect(range(0.7, 2.1; length=15))
+ws = collect(range(0.7, 2.1; length=cfg.n_freqs))
 Δns = [Δn_of([w]) for w in ws]
 Λs = [λF/(2d) for d in Δns]
 

--- a/examples/dichroic_filter_magden2018.jl
+++ b/examples/dichroic_filter_magden2018.jl
@@ -17,11 +17,17 @@
 #       the ideal adiabatic mode-evolution short-pass (WGA) / long-pass (WGB) response.
 #   (4) supermode |E| profiles below / at / above cutoff (Fig. 1d: field shifts WGA → WGB).
 #
+# Settings (see examples/README.md): --n-freqs (dispersion/crossing sweep points, default 6),
+# --n-dense (interpolated transmission-curve resolution, default 400), --resolution-scale /
+# --domain-scale (grid).
+#
 # Run:  julia --project=. examples/dichroic_filter_magden2018.jl   (needs CairoMakie)
+#       julia --project=. examples/dichroic_filter_magden2018.jl --n-freqs=10 --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "eme_reproductions_common.jl"))
 using CairoMakie
 
+cfg = example_settings(n_freqs=6, n_dense=400)
 solver = KrylovKitEigsolve()
 H = 0.22                                   # 220-nm SOI silicon thickness
 wA = 0.318                                  # WGA solid-Si strip width
@@ -33,7 +39,7 @@ xB = +(edge_gap/2 + wB/2)
 x_split = (xA + wA/2 + xB - wB/2)/2          # WGA|WGB divider (gap midpoint)
 mats = [silicon, SiO₂]
 mv = matvals_builder(mats; air=false)        # Si core, SiO₂ background (buried)
-grid = Grid(4.4, 2.2, 124, 62)
+grid = mk_grid(cfg, 4.4, 2.2, 124, 62)
 
 rect(cx, w) = MaterialShape(Cuboid([cx, 0.0], [w, H], [1.0 0.0; 0.0 1.0]), 1)
 shapes_A = (rect(xA, wA),)                                        # WGA alone
@@ -43,7 +49,7 @@ minds_A = (1, 2); minds_B = (1, 1, 1, 2); minds_AB = (1, 1, 1, 1, 2)
 
 # --- (1,2) isolated dispersion + mode crossing (cutoff) ---------------------------------
 println("== Si dichroic filter: isolated WGA / WGB dispersion (>1 octave) ==")
-λs = collect(range(1.40, 2.60; length=6))       # 1.35–2.65 µm ≈ 0.97 octave (moderate grid; scale via SLURM)
+λs = collect(range(1.40, 2.60; length=cfg.n_freqs))   # 1.35–2.65 µm ≈ 0.97 octave (moderate grid; scale via SLURM)
 nA = zero(λs); nB = zero(λs); fracA = zero(λs)
 for (j, λ) in enumerate(λs)
     ω = 1/λ
@@ -57,7 +63,7 @@ end
 @printf("cutoff λ_C (β_A = β_B): %s µm\n", isnan(λC) ? "none in range" : string(round(λC; digits=3)))
 
 # --- (3) dense >1-octave transmission spectrum -----------------------------------------
-λdense = collect(range(λs[1], λs[end]; length=400))
+λdense = collect(range(λs[1], λs[end]; length=cfg.n_dense))
 T_short, T_long = dichroic_spectrum(λs, fracA, λdense)
 
 # --- (4) supermode profiles below / at / above cutoff ----------------------------------

--- a/examples/eme_reproductions_common.jl
+++ b/examples/eme_reproductions_common.jl
@@ -21,8 +21,8 @@
 # Grids are moderate so the plots generate on a workstation; the dense EME sweep deploys to a
 # cluster via `deploy_eme`/`gather_eme` (as the MEOW fork's *_slurm.py designers do).
 
-include(joinpath(@__DIR__, "paper_reproductions_common.jl"))   # Grid, solve_fundamental, matvals_builder, grid_coords, absE_norm, OUTDIR, C_MS
-using OptiMode.EigenmodeExpansion: CrossSection, Cell, eme, power_coupling
+include(joinpath(@__DIR__, "paper_reproductions_common.jl"))   # Grid, solve_fundamental, matvals_builder, grid_coords, absE_norm, OUTDIR, C_MS, ExampleSettings, example_settings, mk_grid
+using OptiMode.EigenmodeExpansion: CrossSection, Cell, eme, power_coupling, transmission
 using OptiMode.MaterialDispersion: Vacuum
 using OptiMode: E⃗, E_relpower_xyz, solve_k, sliceinv_3x3, smooth_ε, MaterialShape
 using OptiMode.DielectricSmoothing.GeometryPrimitives: Cuboid
@@ -105,4 +105,41 @@ function eme_transmission(cell_shapes, minds, materials, ω, grid, s_edges, solv
         push!(cells, Cell(i, sc, L, CrossSection(collect(MaterialShape, cell_shapes[i]), copy(mind_vec))))
     end
     eme(cells, materials, ω, grid, solver; nev=nev, k_tol=1e-7)
+end
+
+# ---------------------------------------------------------------------------------------
+# True EME bar/cross transmission of a two-waveguide directional coupler
+# ---------------------------------------------------------------------------------------
+
+"""
+    port_transmission(S) -> (; T_bar, T_cross)
+
+Bar/cross transmission from the 2×2 (even,odd)-supermode transmission block of an EME
+scattering matrix `S`, by projecting onto the launch/detection port vectors
+`v_bar=[1,1]/√2`, `v_cross=[1,-1]/√2` — the exact symmetric/antisymmetric decomposition of a
+single-waveguide excitation into the even/odd supermodes for a laterally mirror-symmetric
+coupler. This is OptiMode's actual EME scattering matrix, not a hand-applied sin²(πLΔn/λ)
+formula (though for a *uniform* single-cell coupler the two are identical by construction —
+see module docs)."""
+function port_transmission(S)
+    Tblock = transmission(S)[1:2, 1:2]
+    v_bar, v_cross = [1, 1] ./ sqrt(2), [1, -1] ./ sqrt(2)
+    a_out = Tblock * v_bar                               # launch ≈ (even+odd)/√2 (left waveguide)
+    (; T_bar=abs2(v_bar ⋅ a_out), T_cross=abs2(v_cross ⋅ a_out))
+end
+
+"""
+    directional_coupler_transmission(coupler_shapes, minds, materials, ω, grid, L, solver; nev=4)
+        -> (; T_bar, T_cross, k_even, k_odd)
+
+Bar/cross transmission of a *uniform* (constant cross-section) two-waveguide directional
+coupler of length `L`, from a single-cell EME solve (`eme` on the coupled cross-section, so
+`result.S` is exactly the propagation matrix `diag(exp(2πi k_even L), exp(2πi k_odd L), …)`)
+projected through [`port_transmission`](@ref). Assumes the two lowest-`k` modes returned are
+the TE-like even/odd supermode pair (as elsewhere in this file)."""
+function directional_coupler_transmission(coupler_shapes, minds, materials, ω, grid, L, solver; nev=4)
+    mind_vec = collect(Int, minds)
+    cell = Cell(1, L/2, L, CrossSection(collect(MaterialShape, coupler_shapes), mind_vec))
+    res = eme([cell], materials, ω, grid, solver; nev=nev, k_tol=1e-7)
+    (; port_transmission(res.S)..., k_even=res.modes[1][1].k, k_odd=res.modes[1][2].k)
 end

--- a/examples/example_settings.jl
+++ b/examples/example_settings.jl
@@ -1,0 +1,152 @@
+# Shared, a-la-carte accuracy/run-mode settings for the paper-reproduction, EME, and designer
+# examples (the `*_reproduction*`/`*_designer*`/EME family that `include` this file — directly
+# or via `paper_reproductions_common.jl` / `eme_reproductions_common.jl` / `designer_common.jl`).
+#
+# Every knob can be set three equivalent ways, resolved with this precedence
+# (highest wins): command-line flag > environment variable > the script's own
+# `example_settings(...)` keyword > the built-in default below. That lets a user override a
+# script's tuned defaults at the command line or via the environment without editing source,
+# while each example still ships sensible, pre-validated defaults.
+#
+#   julia examples/tantala_gvd_black2021.jl --resolution-scale=2 --n-freqs=25
+#   OPTIMODE_N_FREQS=25 julia examples/tantala_gvd_black2021.jl
+#   example_settings(n_freqs=25)   # inside the script itself
+#
+# See examples/README.md for the full settings reference and worked examples.
+
+export ExampleSettings, example_settings, mk_grid
+
+"""
+    ExampleSettings
+
+Resolved a-la-carte simulation settings for one example run.
+
+- `resolution_scale` — multiplies every example's baseline grid point count (finer/coarser mesh
+  at fixed physical domain size). `1.0` reproduces the script's validated default grid.
+- `domain_scale` — multiplies every example's baseline physical domain size (`Lx`, `Ly`), i.e.
+  how far the simulation boundary sits from the waveguide core; grid point counts scale with it
+  too so the resolution (points/µm) stays fixed when only `domain_scale` changes.
+- `n_freqs` — number of wavelengths (or other swept parameter) in a *mode-solve* sweep (isolated
+  dispersion, QPM tuning, supermode crossing, …) — the expensive, per-point-eigensolve knob.
+- `n_dense` — number of points in a *cheap, closed-form* dense curve (interpolated transmission,
+  analytic gain/QPM-mismatch spectra) — free to make large; only affects plot smoothness.
+- `n_eme_freqs` — number of wavelengths for a genuinely EME-solved (`eme`/`power_coupling`) dense
+  transmission overlay, where the example provides one (see `tfln_combiner_kwolek2026.jl`).
+- `n_cells` — number of cells in an EME cascade (`eme_transmission`/`Cell` count).
+- `run_mode` — `:local` (default) or `:slurm`. These example scripts run their (few-point)
+  mode-solve sweeps inline; `:slurm` is accepted and resolved consistently but only *acted on* by
+  scripts that say so in their header. For cluster-scale sweeps use the dedicated ModeSweeps
+  entry points (`remote_mode_solve.jl`, `remote_adjoint_optimization.jl`,
+  `tfln_ppln_geometry_sweep_deploy.jl`), which already accept a `SlurmConfig`.
+- `slurm` — a `ModeSweeps.SlurmConfig` (or `nothing`); only settable via the `example_settings`
+  keyword (not CLI/ENV, since it has many sub-fields) — see `remote_mode_solve.jl` for its API.
+"""
+Base.@kwdef struct ExampleSettings
+    resolution_scale::Float64 = 1.0
+    domain_scale::Float64 = 1.0
+    n_freqs::Int = 9
+    n_dense::Int = 400
+    n_eme_freqs::Int = 15
+    n_cells::Int = 6
+    run_mode::Symbol = :local
+    slurm::Any = nothing
+end
+
+function Base.show(io::IO, cfg::ExampleSettings)
+    print(io, "ExampleSettings(resolution_scale=", cfg.resolution_scale,
+          ", domain_scale=", cfg.domain_scale, ", n_freqs=", cfg.n_freqs,
+          ", n_dense=", cfg.n_dense, ", n_eme_freqs=", cfg.n_eme_freqs,
+          ", n_cells=", cfg.n_cells, ", run_mode=", cfg.run_mode, ")")
+end
+
+# ---------------------------------------------------------------------------------------
+# kwarg / CLI / ENV resolution
+# ---------------------------------------------------------------------------------------
+
+const _SETTINGS_SPEC = (
+    (:resolution_scale, 1.0,     s -> parse(Float64, s)),
+    (:domain_scale,      1.0,     s -> parse(Float64, s)),
+    (:n_freqs,           9,       s -> parse(Int, s)),
+    (:n_dense,           400,     s -> parse(Int, s)),
+    (:n_eme_freqs,       15,      s -> parse(Int, s)),
+    (:n_cells,           6,       s -> parse(Int, s)),
+    (:run_mode,          :local,  s -> Symbol(lowercase(s))),
+)
+
+_cli_flag(name::Symbol) = "--" * replace(String(name), "_" => "-")
+_env_key(name::Symbol) = "OPTIMODE_" * uppercase(String(name))
+
+"Value of `--flag=value` or `--flag value` in `ARGS`, or `nothing` if absent."
+function _cli_value(name::Symbol)
+    flag = _cli_flag(name)
+    for (i, a) in enumerate(ARGS)
+        if startswith(a, flag * "=")
+            return a[length(flag)+2:end]
+        elseif a == flag && i < length(ARGS)
+            return ARGS[i+1]
+        end
+    end
+    return nothing
+end
+
+_env_value(name::Symbol) = get(ENV, _env_key(name), nothing)
+
+function _print_settings_help()
+    println("Available example settings (CLI flag / env var / keyword — highest precedence first):")
+    for (name, default, _) in _SETTINGS_SPEC
+        @printf("  %-22s  %-28s  %-14s  (default %s)\n",
+                _cli_flag(name), _env_key(name), string(name), string(default))
+    end
+    println("  --help / -h            (this message)")
+    println("\nExamples:")
+    println("  julia --project=. examples/tantala_gvd_black2021.jl --resolution-scale=2 --n-freqs=25")
+    println("  OPTIMODE_N_FREQS=25 julia --project=. examples/tantala_gvd_black2021.jl")
+    println("See examples/README.md for the full reference.")
+end
+
+"""
+    example_settings(; kwargs...) -> ExampleSettings
+
+Resolve this run's settings. Each field may be set (in increasing precedence) by the built-in
+default, a keyword passed here (a script's own tuned default), an `OPTIMODE_<NAME>` environment
+variable, or a `--<name-with-dashes>[=value]` command-line flag. `--help`/`-h` prints the
+settings reference and exits. `slurm` (a `ModeSweeps.SlurmConfig`) is keyword-only.
+"""
+function example_settings(; kwargs...)
+    if "--help" in ARGS || "-h" in ARGS
+        _print_settings_help()
+        exit(0)
+    end
+    kw = Dict{Symbol,Any}(kwargs)
+    vals = Dict{Symbol,Any}()
+    for (name, default, parse_fn) in _SETTINGS_SPEC
+        v = haskey(kw, name) ? kw[name] : default
+        ev = _env_value(name); ev === nothing || (v = parse_fn(ev))
+        cv = _cli_value(name); cv === nothing || (v = parse_fn(cv))
+        vals[name] = v
+    end
+    vals[:run_mode] in (:local, :slurm) ||
+        throw(ArgumentError("run_mode must be :local or :slurm, got $(repr(vals[:run_mode]))"))
+    cfg = ExampleSettings(; vals..., slurm=get(kw, :slurm, nothing))
+    println("== settings: ", cfg, " ==")
+    cfg
+end
+
+# ---------------------------------------------------------------------------------------
+# Grid construction from resolution_scale / domain_scale
+# ---------------------------------------------------------------------------------------
+
+"""
+    mk_grid(cfg, Lx0, Ly0, nx0, ny0) -> Grid
+
+Build the simulation `Grid` from an example's validated baseline domain size (`Lx0`, `Ly0`, µm)
+and point counts (`nx0`, `ny0`) at `cfg.resolution_scale = cfg.domain_scale = 1`. `domain_scale`
+scales the physical domain (how far the boundary sits from the core), carrying the point count
+along so the resolution (points/µm) is unchanged; `resolution_scale` then further refines/coarsens
+the mesh at whatever domain size resulted."""
+function mk_grid(cfg::ExampleSettings, Lx0::Real, Ly0::Real, nx0::Integer, ny0::Integer)
+    Lx, Ly = Lx0 * cfg.domain_scale, Ly0 * cfg.domain_scale
+    nx = max(4, round(Int, nx0 * cfg.domain_scale * cfg.resolution_scale))
+    ny = max(4, round(Int, ny0 * cfg.domain_scale * cfg.resolution_scale))
+    Grid(Lx, Ly, nx, ny)
+end

--- a/examples/paper_reproductions_common.jl
+++ b/examples/paper_reproductions_common.jl
@@ -27,6 +27,8 @@ using OptiMode.ModePerturbations: effective_area_kerr, kerr_gamma,
 using LinearAlgebra
 using Printf
 
+include(joinpath(@__DIR__, "example_settings.jl"))   # ExampleSettings, example_settings, mk_grid
+
 const C_MS   = 299792458.0            # speed of light (m/s)
 const C_UM_FS = C_MS * 1e-9           # speed of light (µm/fs) = 0.299792458
 const OUTDIR = joinpath(@__DIR__, "paper_reproduction_output")

--- a/examples/ppln_reconfigurable_opa_han2026.jl
+++ b/examples/ppln_reconfigurable_opa_han2026.jl
@@ -15,7 +15,11 @@
 #   (3) the χ² nonlinear coupling: normalized efficiency η₀ and SHG effective area A_eff;
 #   (4) the FH (1064 nm) and SH (532 nm) fundamental-mode profiles (Fig. 1c).
 #
+# Settings (see examples/README.md): --n-freqs (dispersion-sweep points, default 5), --n-dense
+# (χ² gain-spectrum resolution, default 601), --resolution-scale / --domain-scale (grid).
+#
 # Run:  julia --project=. examples/ppln_reconfigurable_opa_han2026.jl   (needs CairoMakie)
+#       julia --project=. examples/ppln_reconfigurable_opa_han2026.jl --n-freqs=9 --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "paper_reproductions_common.jl"))
 using OptiMode: rotate
@@ -23,6 +27,7 @@ using OptiMode.MaterialDispersion: LiNbO₃
 using OptiMode.ModePerturbations: shg_normalized_efficiency, shg_effective_area
 using CairoMakie
 
+cfg = example_settings(n_freqs=5, n_dense=601)
 solver = KrylovKitEigsolve()
 λF = 1.064; λS = λF/2                        # 1064 nm FH → 532 nm SH
 w, etch, film = 1.40, 0.35, 0.70            # x-cut TFLN ridge (representative near-zero-β₂ design)
@@ -33,12 +38,12 @@ LiNbO₃_xcut = rotate(LiNbO₃, _RY; name=:LiNbO₃_xcut)
 mv = matvals_builder([LiNbO₃_xcut, SiO₂]; air=true)     # columns: LN, SiO₂, air
 shapes, minds = ridge_on_slab(w, etch, film)
 slab = film - etch
-grid = Grid(6.0, 4.0, 116, 78)
+grid = mk_grid(cfg, 6.0, 4.0, 116, 78)
 D33 = 20.5; deff = (2/π) * D33 * 1e-12       # first-order-QPM d_eff (m/V), LiNbO₃ d₃₃≈20.5 pm/V
 
 # --- (1) FH-band modal dispersion -------------------------------------------------------
 println("== TFLN x-cut ridge: fundamental (1064 nm band) dispersion ==")
-λFH = range(1.01, 1.13; length=5)
+λFH = range(1.01, 1.13; length=cfg.n_freqs)
 swF = sweep_dispersion(shapes, minds, mv, λFH, grid, solver; pol=:TE, w=w, h=film, yc=slab, nev=6)
 β2F, β4F = dispersion_betas(swF, λF)
 @printf("β₂(1064) = %+.1f fs²/mm,  β₄(1064) = %+.0f fs⁴/mm   (paper: −3.6, 543)\n", β2F, β4F)
@@ -62,7 +67,7 @@ qpm = qpm_mismatch_spectrum(swF.neff, swS.neff, swF.λ, Λ)
 # --- χ² OPA gain bandwidth near degeneracy (SH-pumped) ----------------------------------
 P_SH = 0.05                                   # 50 mW SH pump
 Γ = sqrt((η0/100*1e4) * P_SH)                 # drive √(η₀ P_SH), 1/m
-gn = chi2_opa_gain_spectrum(swF, λF, Γ; L=0.01, Ω_THz=range(-150, 150; length=601))
+gn = chi2_opa_gain_spectrum(swF, λF, Γ; L=0.01, Ω_THz=range(-150, 150; length=cfg.n_dense))
 @printf("χ² OPA drive Γ=%.1f /m,  peak gain %.1f dB,  3-dB BW %.0f THz\n",
         Γ, maximum(gn.gain_dB), gn.bw3_THz)
 

--- a/examples/ppln_thermal_tuning_han2026.jl
+++ b/examples/ppln_thermal_tuning_han2026.jl
@@ -12,13 +12,18 @@
 #   (2) the phase-matched FH wavelength λ_PM vs ΔT (the electro-thermal tuning curve);
 #   (3) the effective-index thermo-optic coefficients dn_eff/dT of the FH and SH modes.
 #
+# Settings (see examples/README.md): --n-freqs (dispersion-sweep points, default 3), --n-dense
+# (Δk(λ) curve resolution, default 300), --resolution-scale / --domain-scale (grid).
+#
 # Run:  julia --project=. examples/ppln_thermal_tuning_han2026.jl   (needs CairoMakie)
+#       julia --project=. examples/ppln_thermal_tuning_han2026.jl --n-freqs=7 --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "paper_reproductions_common.jl"))
 using OptiMode: rotate
 using OptiMode.MaterialDispersion: LiNbO₃
 using CairoMakie
 
+cfg = example_settings(n_freqs=3, n_dense=300)
 solver = KrylovKitEigsolve()
 λF = 1.064; λS = λF/2
 w, etch, film = 1.40, 0.35, 0.70
@@ -30,11 +35,11 @@ mvT = matvals_builder_T([LiNbO₃_xcut, SiO₂]; air=true)   # (ω, T) → mater
 mv_at(T) = (ω -> mvT(ω, T))                               # freeze temperature for a mode solve
 shapes, minds = ridge_on_slab(w, etch, film)
 slab = film - etch
-grid = Grid(6.0, 4.0, 96, 64)
+grid = mk_grid(cfg, 6.0, 4.0, 96, 64)
 
 # --- FH & SH band dispersion at the reference temperature -------------------------------
 println("== TFLN QPM thermal tuning: dispersion at T₀ = $(T0) °C ==")
-λFH = range(1.02, 1.12; length=3)
+λFH = range(1.02, 1.12; length=cfg.n_freqs)
 swF = sweep_dispersion(shapes, minds, mv_at(T0), λFH, grid, solver; pol=:TE, w=w, h=film, yc=slab, nev=6)
 swS = sweep_dispersion(shapes, minds, mv_at(T0), λFH ./ 2, grid, solver; pol=:TE, w=w, h=film, yc=slab, nev=9)
 mF0 = solve_fundamental(shapes, minds, mv_at(T0), 1/λF, grid, solver; nev=6, pol=:TE, w=w, h=film, yc=slab)
@@ -74,7 +79,7 @@ dλ_dT = (λpms[end]-λpms[1])/(ΔTs[end]-ΔTs[1])
 @printf("thermal tuning slope dλ_PM/dT ≈ %.2f nm/K\n", 1e3*dλ_dT)
 
 # --- plots ------------------------------------------------------------------------------
-λdense = range(λFH[1], λFH[end]; length=300)
+λdense = range(λFH[1], λFH[end]; length=cfg.n_dense)
 
 fig1 = Figure(size=(920, 340))
 ax1 = Axis(fig1[1, 1], xlabel="FH wavelength (µm)", ylabel="QPM Δk (rad/mm)",

--- a/examples/pplt_allband_opa_kuznetsov2026.jl
+++ b/examples/pplt_allband_opa_kuznetsov2026.jl
@@ -16,7 +16,11 @@
 #       n₂,eff(Δk) (sign-changing across phase matching — the amplifier's working nonlinearity);
 #   (4) the FH (1550 nm) and SH (775 nm) quasi-TE₀₀ mode profiles.
 #
+# Settings (see examples/README.md): --n-freqs (dispersion-sweep points, default 5), --n-dense
+# (cascaded-n₂ curve resolution, default 401), --resolution-scale / --domain-scale (grid).
+#
 # Run:  julia --project=. examples/pplt_allband_opa_kuznetsov2026.jl   (needs CairoMakie)
+#       julia --project=. examples/pplt_allband_opa_kuznetsov2026.jl --n-freqs=9 --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "paper_reproductions_common.jl"))
 using OptiMode: rotate
@@ -24,6 +28,7 @@ using OptiMode.MaterialDispersion: LiTaO₃
 using OptiMode.ModePerturbations: shg_normalized_efficiency, shg_effective_area, cascaded_chi2_n2_eff
 using CairoMakie
 
+cfg = example_settings(n_freqs=5, n_dense=401)
 solver = KrylovKitEigsolve()
 λF = 1.55; λS = λF/2                          # 1550 nm FH → 775 nm SH (telecom pump)
 w, etch, film = 1.80, 0.59, 0.69            # 690 nm LiTaO₃, ~100 nm slab, 1.8 µm top width
@@ -34,12 +39,12 @@ LiTaO₃_xcut = rotate(LiTaO₃, _RY; name=:LiTaO₃_xcut)
 mv = matvals_builder([LiTaO₃_xcut, SiO₂]; air=true)      # columns: LiTaO₃, SiO₂, air
 shapes, minds = ridge_on_slab(w, etch, film)
 slab = film - etch
-grid = Grid(8.0, 5.0, 116, 76)
+grid = mk_grid(cfg, 8.0, 5.0, 116, 76)
 D33 = 10.7; deff = (2/π) * D33 * 1e-12       # first-order-QPM d_eff (m/V), LiTaO₃ d₃₃≈10.7 pm/V
 
 # --- (1) telecom-band modal dispersion --------------------------------------------------
 println("== PPLT x-cut ridge: telecom (1550 nm) band dispersion ==")
-λFH = range(1.48, 1.62; length=5)
+λFH = range(1.48, 1.62; length=cfg.n_freqs)
 swF = sweep_dispersion(shapes, minds, mv, λFH, grid, solver; pol=:TE, w=w, h=film, yc=slab, nev=6)
 β2F, β4F = dispersion_betas(swF, λF)
 @printf("β₂(1550) = %+.1f fs²/mm,  β₄(1550) = %+.0f fs⁴/mm\n", β2F, β4F)
@@ -62,7 +67,7 @@ Aeff = shg_effective_area(mF.E, mS.E, grid)
 qpm = qpm_mismatch_spectrum(swF.neff, swS.neff, swF.λ, Λ)
 
 # --- (3) cascaded-χ² effective Kerr n₂,eff(Δk) ------------------------------------------
-Δk_range = range(-4000, 4000; length=401)     # phase mismatch (rad/m)
+Δk_range = range(-4000, 4000; length=cfg.n_dense)     # phase mismatch (rad/m)
 n2c = [cascaded_chi2_n2_eff(; deff=deff, λ1=λF*1e-6, n1=nF, n2=nS, Δk=Δk) for Δk in Δk_range]
 
 # --- plots ------------------------------------------------------------------------------

--- a/examples/si3n4_cw_opa_riemensberger2022.jl
+++ b/examples/si3n4_cw_opa_riemensberger2022.jl
@@ -14,25 +14,30 @@
 #   (3) the degenerate-FWM parametric-gain spectrum g(Ω) vs signal wavelength (Eq. 2); and
 #   (4) the fundamental quasi-TE₀₀ mode profile (Fig. 1d inset).
 #
+# Settings (see examples/README.md): --n-freqs (dispersion-sweep points, default 13), --n-dense
+# (FWM gain-spectrum resolution, default 321), --resolution-scale / --domain-scale (grid).
+#
 # Run:  julia --project=. examples/si3n4_cw_opa_riemensberger2022.jl
 # (needs CairoMakie in the active environment; grid is moderate so it runs in a few minutes —
 #  the converged design sweep deploys via ModeSweeps/SLURM.)
+#       julia --project=. examples/si3n4_cw_opa_riemensberger2022.jl --n-freqs=25 --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "paper_reproductions_common.jl"))
 using OptiMode.MaterialDispersion: kerr_n2
 using CairoMakie
 
+cfg = example_settings(n_freqs=13, n_dense=321)
 solver = KrylovKitEigsolve()
 w, h = 2.45, 0.91                       # 2450 nm width × 910 nm height (Riemensberger 2022)
 λp = 1.55                                # C-band pump
 mats = [Si₃N₄, SiO₂]
 mv = matvals_builder(mats; air=false)   # Si₃N₄ core fully buried in SiO₂
 shapes, minds = buried_core(w, h)
-grid = Grid(6.0, 4.0, 128, 96)
+grid = mk_grid(cfg, 6.0, 4.0, 128, 96)
 
 # --- (1) modal dispersion spectra -------------------------------------------------------
 println("== Si₃N₄ 910×2450 nm: modal dispersion sweep ==")
-λs = range(1.40, 1.70; length=13)
+λs = range(1.40, 1.70; length=cfg.n_freqs)
 sw = sweep_dispersion(shapes, minds, mv, λs, grid, solver; pol=:TE, w=w, h=h, nev=4)
 β2_p = sw.β2[argmin(abs.(sw.λ .- λp))]
 @printf("β₂(1.55 µm) ≈ %.0f fs²/mm   (paper: −124 fs²/mm)\n", β2_p)
@@ -46,7 +51,7 @@ n2 = kerr_n2(Si₃N₄, λp)                  # µm²/W
 
 # --- (3) degenerate-FWM parametric-gain spectrum ---------------------------------------
 P, L = 2.0, 1.0                          # 2 W on-chip pump, 1 m waveguide (metre-scale spiral)
-fw = fwm_gain_spectrum(sw, λp, P, γ; L=L, Ω_THz=range(-8, 8; length=321))
+fw = fwm_gain_spectrum(sw, λp, P, γ; L=L, Ω_THz=range(-8, 8; length=cfg.n_dense))
 β2_fit = fw.β2 * 1e27      # s²/m → fs²/mm
 β4_fit = fw.β4 * 1e57      # s⁴/m → fs⁴/mm
 @printf("fit β₂ = %+.1f fs²/mm, β₄ = %+.0f fs⁴/mm;  peak gain %.1f dB,  3-dB BW %.2f THz\n",

--- a/examples/tantala_gvd_black2021.jl
+++ b/examples/tantala_gvd_black2021.jl
@@ -12,13 +12,18 @@
 #   (3) the degenerate-FWM parametric-gain spectrum (tantala is a χ³ platform); and
 #   (4) the fundamental quasi-TE₀₀ mode profile (Fig. 1b inset).
 #
+# Settings (see examples/README.md): --n-freqs (dispersion-sweep points, default 13), --n-dense
+# (FWM gain-spectrum resolution, default 401), --resolution-scale / --domain-scale (grid).
+#
 # Run:  julia --project=. examples/tantala_gvd_black2021.jl   (needs CairoMakie)
+#       julia --project=. examples/tantala_gvd_black2021.jl --n-freqs=25 --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "paper_reproductions_common.jl"))
 using OptiMode.MaterialDispersion: kerr_n2
 using OptiMode.DielectricSmoothing.GeometryPrimitives: Cuboid
 using CairoMakie
 
+cfg = example_settings(n_freqs=13, n_dense=401)
 solver = KrylovKitEigsolve()
 t, w = 1.0, 1.25                          # thickness 1 µm, width 1.25·t (Black 2021, Fig. 1b)
 λp = 1.55
@@ -29,12 +34,12 @@ mv = matvals_builder(mats; air=true)     # columns: Ta₂O₅, SiO₂, air
 shapes = ( MaterialShape(Cuboid([0.0, t/2], [w, t], [1.0 0.0; 0.0 1.0]), 1),          # core (Ta₂O₅)
            MaterialShape(Cuboid([0.0, -1.5], [100.0, 3.0], [1.0 0.0; 0.0 1.0]), 2) )  # SiO₂ substrate
 minds = (1, 2, 3)                        # core→Ta₂O₅, substrate→SiO₂, background→air
-grid = Grid(5.0, 4.0, 128, 100)
+grid = mk_grid(cfg, 5.0, 4.0, 128, 100)
 yc = t/2                                  # core center height for confinement mask
 
 # --- (1) modal dispersion spectra -------------------------------------------------------
 println("== Ta₂O₅ 1.0×1.25 µm on SiO₂ (air clad): dispersion sweep ==")
-λs = range(0.9, 2.3; length=13)
+λs = range(0.9, 2.3; length=cfg.n_freqs)
 sw = sweep_dispersion(shapes, minds, mv, λs, grid, solver; pol=:TE, w=w, h=t, yc=yc, nev=4)
 # zero-dispersion wavelengths (β₂ sign changes)
 zdw = Float64[]
@@ -54,7 +59,7 @@ n2 = kerr_n2(Ta₂O₅, λp)
 
 # --- (3) degenerate-FWM parametric-gain spectrum ---------------------------------------
 P, L = 5.0, 0.1                           # 5 W, 10 cm (tantala nonlinear waveguide)
-fw = fwm_gain_spectrum(sw, λp, P, γ; L=L, Ω_THz=range(-30, 30; length=401))
+fw = fwm_gain_spectrum(sw, λp, P, γ; L=L, Ω_THz=range(-30, 30; length=cfg.n_dense))
 @printf("fit β₂ = %+.1f fs²/mm, β₄ = %+.0f fs⁴/mm;  peak gain %.1f dB,  3-dB BW %.1f THz\n",
         fw.β2*1e27, fw.β4*1e57, maximum(fw.gain_dB), fw.bw3_THz)
 

--- a/examples/tfln_combiner_kwolek2026.jl
+++ b/examples/tfln_combiner_kwolek2026.jl
@@ -13,18 +13,34 @@
 # Following the MEOW-fork example (examples/papers/kwolek2026_faquad.py) but with OptiMode:
 #   (1) MODE SOLVING + DISPERSION: even/odd supermode indices of the two-ridge coupler across
 #       > 1 octave (0.70–1.65 µm), and the coupling length L_c(λ)=λ/(2Δn_super).
-#   (2) DENSE >1-OCTAVE TRANSMISSION SPECTRUM: directional-coupler bar/cross transmission
-#       T_cross(λ)=sin²(πL·Δn_super(λ)/λ) — strong FH coupling (→ cross) vs weak SH coupling
+#   (2) DENSE >1-OCTAVE TRANSMISSION SPECTRUM: two curves overlaid —
+#         (a) a cheap analytic curve T_cross(λ)=sin²(πL·Δn_super(λ)/λ), with Δn_super(λ)
+#             linearly interpolated from the (1) sparse mode-solve dispersion, sampled at
+#             `cfg.n_dense` points for a smooth plot;
+#         (b) a genuinely EME-solved curve: OptiMode's actual `eme` scattering matrix
+#             (`directional_coupler_transmission`, no hand-applied formula) evaluated at
+#             `cfg.n_eme_freqs` real (mode-solved, uninterpolated) wavelengths.
+#       (a) and (b) agree wherever they overlap — (a) is only interpolating what (b) computes
+#       exactly — and (b) shows the true device response between the (1) dispersion nodes
+#       without relying on interpolation. Strong FH coupling (→ cross) vs weak SH coupling
 #       (→ bar) gives the wavelength combiner response.
-#   (3) EME validation: cascade the uniform coupler with OptiMode's `eme` (cross-section dedup
-#       makes this cheap) and confirm the supermode S-matrix.
+#   (3) EME cascade validation: cascade `cfg.n_cells` identical cells of the uniform coupler
+#       with OptiMode's `eme` (cross-section dedup makes this cheap) and confirm the cascaded
+#       S-matrix agrees with the single-cell result of (2b).
 #   (4) even/odd supermode |E| profiles at FH and SH.
 #
+# Settings (see examples/README.md): --n-freqs (sparse dispersion nodes, default 7),
+# --n-dense (interpolated curve resolution, default 400), --n-eme-freqs (true EME overlay
+# resolution, default 15), --n-cells (cascade validation cell count, default 6),
+# --resolution-scale / --domain-scale (grid).
+#
 # Run:  julia --project=. examples/tfln_combiner_kwolek2026.jl   (needs CairoMakie)
+#       julia --project=. examples/tfln_combiner_kwolek2026.jl --n-eme-freqs=30 --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "eme_reproductions_common.jl"))
 using CairoMakie
 
+cfg = example_settings(n_freqs=7, n_dense=400, n_eme_freqs=15, n_cells=6)
 solver = KrylovKitEigsolve()
 film, slab, w = 0.30, 0.20, 1.20            # 300-nm film, 200-nm slab (100-nm etch), 1.2-µm width
 etch = film - slab                           # 0.10 µm rib height
@@ -35,7 +51,7 @@ const _RY = [0.0 0.0 1.0; 0.0 1.0 0.0; -1.0 0.0 0.0]
 LiNbO₃_xcut = rotate(LiNbO₃, _RY; name=:LiNbO₃_xcut)
 mats = [LiNbO₃_xcut, SiO₂, Vacuum]
 mv = matvals_builder(mats; air=false)        # LN, SiO₂ box, Vacuum background (air top)
-grid = Grid(7.0, 3.0, 112, 58)
+grid = mk_grid(cfg, 7.0, 3.0, 112, 58)
 
 rib(cx) = MaterialShape(Cuboid([cx, slab + etch/2], [w, etch], [1.0 0.0; 0.0 1.0]), 1)
 slabsh  = MaterialShape(Cuboid([0.0, slab/2], [200.0, slab], [1.0 0.0; 0.0 1.0]), 1)
@@ -46,7 +62,7 @@ minds   = (1, 1, 1, 2, 3)
 
 # --- (1) even/odd supermode dispersion over > 1 octave ---------------------------------
 println("== TFLN combiner: even/odd supermode dispersion (0.70–1.65 µm) ==")
-λs = collect(range(0.74, 1.60; length=7))    # 1.17 octave
+λs = collect(range(0.74, 1.60; length=cfg.n_freqs))    # 1.17 octave
 Δn = zero(λs); Lc = zero(λs)
 for (j, λ) in enumerate(λs)
     sup = supermodes(coupler, minds, mv, 1/λ, grid, solver; nev=4)   # sorted by n_eff desc
@@ -54,30 +70,43 @@ for (j, λ) in enumerate(λs)
     Δn[j] = ne - no
     Lc[j] = λ / (2*abs(Δn[j]))                                        # half-beat coupling length (µm)
     @printf("  λ=%.3f µm  n_even=%.4f  n_odd=%.4f  Δn=%.2e  L_c=%.1f µm\n", λ, ne, no, Δn[j], Lc[j])
+    flush(stdout)
 end
 
 # --- (2) dense directional-coupler combiner transmission -------------------------------
 Lc_FH = interp1(λs, Lc, λF)                   # set device length = one coupling length at FH
 L = Lc_FH                                       # → full cross-over at FH
-λdense = collect(range(λs[1], λs[end]; length=400))
+
+# (2a) cheap analytic curve — interpolated dispersion, dense for a smooth plot
+λdense = collect(range(λs[1], λs[end]; length=cfg.n_dense))
 Δn_d = [interp1(λs, Δn, λ) for λ in λdense]
 T_cross = [sin(π * L * abs(Δn_d[i]) / λdense[i])^2 for i in eachindex(λdense)]
 T_bar = 1 .- T_cross
-@printf("device length L = L_c(FH) = %.1f µm;  T_cross(FH)=%.2f  T_cross(SH)=%.2f\n",
+@printf("device length L = L_c(FH) = %.1f µm;  T_cross(FH)=%.2f  T_cross(SH)=%.2f  (analytic, interpolated)\n",
         L, sin(π*L*abs(interp1(λs,Δn,λF))/λF)^2, sin(π*L*abs(interp1(λs,Δn,λS))/λS)^2)
 
-# --- (3) EME validation of the uniform coupler (dedup-cheap) ---------------------------
-println("== EME validation (uniform coupler, cross-section dedup) ==")
-Ncell = 6
-s_edges = collect(range(0.0, L; length=Ncell+1))
-cell_shapes = fill(coupler, Ncell)
+# (2b) true EME curve — OptiMode's actual eme()/S-matrix at real, uninterpolated wavelengths
+println("== EME-calculated combiner transmission (real mode solves, no interpolation) ==")
+λeme = collect(range(λs[1], λs[end]; length=cfg.n_eme_freqs))
+T_cross_eme = zero(λeme); T_bar_eme = zero(λeme)
+for (j, λ) in enumerate(λeme)
+    dc = directional_coupler_transmission(coupler, minds, mats, 1/λ, grid, L, solver; nev=4)
+    T_cross_eme[j], T_bar_eme[j] = dc.T_cross, dc.T_bar
+    @printf("  λ=%.3f µm  EME k_even=%.4f k_odd=%.4f → T_cross=%.2f  T_bar=%.2f\n",
+            λ, dc.k_even, dc.k_odd, dc.T_cross, dc.T_bar)
+    flush(stdout)
+end
+
+# --- (3) EME cascade validation: cfg.n_cells identical cells vs. the single-cell result -----
+println("== EME cascade validation ($(cfg.n_cells) identical cells, cross-section dedup) ==")
+s_edges = collect(range(0.0, L; length=cfg.n_cells + 1))
+cell_shapes = fill(coupler, cfg.n_cells)
 try
     for λ in (λF, λS)
         res = eme_transmission(cell_shapes, minds, mats, 1/λ, grid, s_edges, solver; nev=4)
-        # bar/cross from the two supermode propagation phases k_even, k_odd
-        ke, ko = res.modes[1][1].k, res.modes[1][2].k
-        tc = sin(π * L * abs(ke - ko))^2
-        @printf("  λ=%.3f µm  EME supermodes k_even=%.4f k_odd=%.4f → T_cross=%.2f\n", λ, ke, ko, tc)
+        pt = port_transmission(res.S)
+        @printf("  λ=%.3f µm  %d-cell cascade → T_cross=%.4f  T_bar=%.4f\n", λ, cfg.n_cells, pt.T_cross, pt.T_bar)
+        flush(stdout)
     end
 catch err
     @warn "EME cascade validation skipped" exception = (err, catch_backtrace())
@@ -96,9 +125,11 @@ vlines!(ax1, [λS, λF], color=:gray, linestyle=:dash)
 text!(ax1, λS, minimum(abs.(Δn)); text="SH", align=(:center,:bottom)); text!(ax1, λF, minimum(abs.(Δn)); text="FH", align=(:center,:bottom))
 ax1b = Axis(fig1[1, 2], xlabel="wavelength (µm)", ylabel="transmission",
     title=@sprintf("combiner response (L=%.0f µm)", L))
-lines!(ax1b, λdense, T_cross, color=:crimson, linewidth=2, label="cross port")
-lines!(ax1b, λdense, T_bar, color=:dodgerblue, linewidth=2, label="bar port")
-vlines!(ax1b, [λS, λF], color=:gray, linestyle=:dash); axislegend(ax1b, position=:rc)
+lines!(ax1b, λdense, T_cross, color=:crimson, linewidth=2, label="cross port (analytic, interpolated)")
+lines!(ax1b, λdense, T_bar, color=:dodgerblue, linewidth=2, label="bar port (analytic, interpolated)")
+scatter!(ax1b, λeme, T_cross_eme, color=:crimson, marker=:circle, markersize=9, strokewidth=1, strokecolor=:black, label="cross port (EME, exact)")
+scatter!(ax1b, λeme, T_bar_eme, color=:dodgerblue, marker=:circle, markersize=9, strokewidth=1, strokecolor=:black, label="bar port (EME, exact)")
+vlines!(ax1b, [λS, λF], color=:gray, linestyle=:dash); axislegend(ax1b, position=:rc, labelsize=10)
 save(joinpath(OUTDIR, "kwolek_combiner_dispersion_transmission.png"), fig1)
 
 fig2 = Figure(size=(1000, 620))


### PR DESCRIPTION
## Summary

- **Fixes the TFLN combiner's transmission plot**: `kwolek_combiner_dispersion_transmission.png`'s dense curve was `sin²(πLΔn(λ)/λ)` with Δn linearly interpolated from only 7 sparse mode-solve points — not a per-wavelength EME calculation. The script's "EME validation" step also wasn't really using the EME S-matrix; it pulled `k_even`/`k_odd` out of an `eme()` call and reapplied the same hand formula.
- Adds `directional_coupler_transmission`/`port_transmission` (`examples/eme_reproductions_common.jl`), which project OptiMode's actual `eme()` scattering matrix onto the physical bar/cross ports (no formula reapplication), and overlays a genuinely EME-solved curve (real per-wavelength solves, no interpolation) on the existing analytic curve in `tfln_combiner_kwolek2026.jl` — they agree throughout the octave, which is itself the validation. The same helper replaces the ad hoc k-based validation step.
- Adds `examples/example_settings.jl`: a shared, a-la-carte settings resolver for the paper-reproduction, EME, and AD-designer examples. Every knob is settable three equivalent ways with precedence **CLI flag > environment variable > script's own keyword > default**:
  - `resolution_scale` / `domain_scale` — grid point density / simulation-boundary distance
  - `n_freqs` — mode-solve sweep points (dispersion, QPM tuning, supermode crossings)
  - `n_dense` — cheap analytic-curve resolution
  - `n_eme_freqs` — true-EME overlay resolution (new)
  - `n_cells` — EME cascade length
  - `run_mode` — `local`/`slurm`, consistently resolved (only the pre-existing ModeSweeps-based examples actually dispatch to SLURM today; this family's sweeps are cheap enough to run inline — documented honestly rather than overclaimed)
- Wires the settings module into all 10 reproduction/EME/designer example scripts in place of their hardcoded `Grid(...)` calls and sweep lengths, preserving each script's validated defaults via its own `example_settings(...)` keywords.
- Adds `examples/README.md`: the settings reference table, worked CLI/env-var/keyword usage examples, an explanation of the combiner's two-curve overlay, and a full catalog of every example script in the repo.

## Testing

All 10 refactored scripts were re-run and produce their expected plots with no errors:
- Full-resolution run of `tfln_combiner_kwolek2026.jl` — the new EME overlay (15 real solves) tracks the analytic curve throughout the 0.74–1.60 µm range.
- Reduced-resolution smoke runs (`--resolution-scale`, `--n-freqs`, `--n-dense` overrides) of the other 9 scripts confirm the settings plumbing (CLI parsing, grid scaling, sweep-length wiring) works end-to-end.

## Test plan
- [x] `tfln_combiner_kwolek2026.jl` full run — EME overlay matches analytic curve
- [x] `tantala_gvd_black2021.jl`, `si3n4_cw_opa_riemensberger2022.jl`, `pplt_allband_opa_kuznetsov2026.jl`, `ppln_reconfigurable_opa_han2026.jl`, `ppln_thermal_tuning_han2026.jl` — smoke-tested with settings overrides
- [x] `dichroic_filter_magden2018.jl` — smoke-tested with settings overrides
- [x] `designer_qpm_mgoln_1310.jl`, `designer_dispersion_tantala_1p3um.jl`, `designer_dichroic_si3n4.jl` — smoke-tested with settings overrides
- [x] `--help` prints the settings reference and exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayn1B3fv797FbNBY2qiSXX)_