### PR TITLE
Enzyme: enable geometry-parameter gradients; convert designer/AD examples

### DIFF
--- a/examples/ad_backend_benchmarks.jl
+++ b/examples/ad_backend_benchmarks.jl
@@ -7,6 +7,11 @@
 #   * solve_k_periodic(Λ)     — z-periodic (Bragg) eigensolve, period derivative
 #   * group_index(ω)          — group-index post-processing (FFT/Tullio)
 #   * neff(ε field)           — sliceinv_3x3 → solve_k (the Enzyme-able sub-stack)
+#   * neff(w) — geometry      — Cuboid width → smooth_ε → sliceinv_3x3 → solve_k. Enzyme only
+#     differentiates this correctly since `DielectricSmoothingEnzymeExt.jl` stopped marking
+#     `surfpt_nearby`/`volfrac`/`_interface_geometry` as `EnzymeRules.inactive` (they carry the
+#     smoothed dielectric's actual geometry dependence; marking them inactive silently zeroed
+#     geometry gradients).
 #
 # Backends: ForwardDiff, Zygote, Mooncake, Enzyme (forward), Enzyme (reverse), and
 # FiniteDifferences as a reference. Each is also checked against the finite-difference
@@ -118,5 +123,14 @@ bench_scalar("ng(solve_k(ω)) end-to-end", ng_end_to_end, ω0, allb)
 # (rrule through the eigensolver); ForwardDiff cannot trace solve_k, so it is reported n/a.
 neff_eps(e) = solve_k(ω0, sliceinv_3x3(e), grid, solver; nev = 1)[1][1] / ω0
 bench_array("neff(ε field) — sliceinv→solve_k", neff_eps, εf, Zygote.gradient(neff_eps, εf)[1], allb)
+
+# geometry-parameter gradient: Cuboid width → smooth_ε → sliceinv_3x3 → solve_k.
+function neff_of_width(w)
+    core_w = MaterialShape(DielectricSmoothing.GeometryPrimitives.Cuboid([0.0, 0.0], [w, 0.7], [1.0 0.0; 0.0 1.0]), 1)
+    sm = smooth_ε((core_w,), mv0, minds, grid)
+    ei = sliceinv_3x3(copy(selectdim(sm, 3, 1)))
+    solve_k(ω0, ei, grid, solver; nev = 1)[1][1] / ω0
+end
+bench_scalar("neff(w) — geometry (Cuboid width) → smooth_ε → solve_k", neff_of_width, 1.6, allb)
 
 println("\nDone.")

--- a/examples/bragg_waveguide_period_adjoint.jl
+++ b/examples/bragg_waveguide_period_adjoint.jl
@@ -12,12 +12,12 @@
 # at ≈one extra eigensolve.
 #
 # Run with a Julia environment that has OptiMode (or its MaxwellEigenmodes
-# component) plus Zygote and FiniteDifferences available.
+# component) plus Enzyme and FiniteDifferences available.
 
 using MaxwellEigenmodes
 using MaxwellEigenmodes.DielectricSmoothing            # Grid, x, y
 using LinearAlgebra, StaticArrays
-using Zygote, FiniteDifferences
+using Enzyme, FiniteDifferences
 
 const solver = KrylovKitEigsolve()
 
@@ -55,7 +55,7 @@ println("neff = $(round(neff, digits=5)),  kz·Λ = $(round(kmags[1]*Λ, digits=
 
 # Adjoint period derivative ∂kz/∂Λ (reverse mode, one extra eigensolve) ...
 kz_of_Λ(L) = solve_k_periodic(ω, epsi, L, grid, solver; nev=1)[1][1]
-dkz_dΛ_adj = Zygote.gradient(kz_of_Λ, Λ)[1]
+dkz_dΛ_adj = Enzyme.gradient(Enzyme.Reverse, kz_of_Λ, Λ)[1]
 # ... checked against a finite-difference reference
 dkz_dΛ_FD = central_fdm(5, 1)(kz_of_Λ, Λ)
 println("∂kz/∂Λ:  adjoint = $(dkz_dΛ_adj)")

--- a/examples/designer_common.jl
+++ b/examples/designer_common.jl
@@ -2,23 +2,28 @@
 # workflow of a reproduction example to a new material stack and new wavelength target and uses
 # OptiMode's automatic differentiation to optimize the waveguide geometry for that target.
 #
-# The geometry gradient is the hybrid forward/reverse scheme of Gray, West & Ram, "Inverse
-# design for waveguide dispersion with a differentiable mode solver," Opt. Express 32, 30541
-# (2024): ForwardDiff carries the geometry parameters through shape construction + Kottke
-# smoothing to the (FFT-free) dielectric fields (exact, thanks to the parametric-eltype
-# GeometryPrimitives fork), and Zygote's reverse adjoint of the eigensolve (`solve_k`'s rrule)
-# supplies the cotangents of the mode quantity w.r.t. those fields; the two are chained. A mode
-# quantity gradient costs ≈ one forward + one adjoint solve, so gradient-based optimization runs
-# on a modest grid in seconds.
+# The geometry gradient is computed by pure Enzyme reverse-mode across the whole pipeline —
+# geometry parameters → shape construction → Kottke smoothing → (FFT-free) dielectric fields →
+# `solve_k`'s adjoint eigensolve → mode quantity — in one `Enzyme.gradient(ReverseWithPrimal, …)`
+# call. This became possible once `DielectricSmoothingEnzymeExt.jl` stopped marking
+# `surfpt_nearby`/`volfrac`/`_interface_geometry` as `EnzymeRules.inactive`: those functions
+# carry the actual geometry dependence of the smoothed dielectric, so marking them inactive
+# (previously done to dodge an old Enzyme Union-type limitation) silently zeroed out geometry
+# gradients. With that fix, Enzyme reproduces ForwardDiff/finite-difference geometry gradients
+# exactly, in both homogeneous- and heterogeneous-shape-type tuples, at the same steady-state
+# cost as the previous ForwardDiff-Jacobian ∘ Zygote-adjoint hybrid scheme of Gray, West & Ram,
+# "Inverse design for waveguide dispersion with a differentiable mode solver," Opt. Express 32,
+# 30541 (2024) (≈ one forward + one adjoint solve per gradient) — but as a single AD backend
+# instead of two composed ones.
 
 include(joinpath(@__DIR__, "paper_reproductions_common.jl"))
 using OptiMode: solve_k, sliceinv_3x3, smooth_ε, E⃗, E_relpower_xyz, group_index, ng_gvd
 using LinearAlgebra
-using ForwardDiff, Zygote
+using Enzyme
 using Printf
 
 # ---------------------------------------------------------------------------------------
-# Hybrid geometry gradient
+# Enzyme geometry gradient
 # ---------------------------------------------------------------------------------------
 
 "Smoothed (ε⁻¹, ∂ωε, ∂²ωε) for a parametric geometry `geomfn(p)` at frequency `om`."
@@ -27,25 +32,26 @@ function diel_p(geomfn, matvals, minds, grid, p, om)
     (sliceinv_3x3(copy(selectdim(sm, 3, 1))), copy(selectdim(sm, 3, 2)), copy(selectdim(sm, 3, 3)))
 end
 
+# Runtime activity: `matvals(om)` (`matvals_builder(...; air=true)`) `hcat`s a computed material
+# column with the literal constant `AIR_COL`; Enzyme's static activity analysis cannot prove
+# that array (mixing constant and active memory in one `hcat`) is safe without this, and raises
+# `EnzymeRuntimeActivityError` — the same fix `ad_backend_benchmarks.jl` already uses.
+const _REVWP = Enzyme.set_runtime_activity(Enzyme.ReverseWithPrimal)
+
 """
     geom_value_grad(fobj, geomfn, matvals, minds, grid, p, om) -> (value, ∇ₚ value)
 
-Value and geometry gradient of a scalar mode functional `fobj(ε⁻¹, ∂ωε)` (e.g. n_eff, n_g),
-via ForwardDiff geometry→dielectric Jacobian ∘ Zygote reverse-adjoint of the eigensolve."""
+Value and geometry gradient of a scalar mode functional `fobj(ε⁻¹, ∂ωε)` (e.g. n_eff, n_g), by
+Enzyme reverse-mode automatic differentiation of the whole geometry→dielectric→eigensolve
+pipeline, in one pass (`ReverseWithPrimal` returns the primal value alongside the gradient)."""
 function geom_value_grad(fobj, geomfn, matvals, minds, grid, p, om)
-    ei0, de0, _ = diel_p(geomfn, matvals, minds, grid, p, om)
-    N = length(vec(ei0))
-    J = ForwardDiff.jacobian(q -> (d = diel_p(geomfn, matvals, minds, grid, q, om); vcat(vec(d[1]), vec(d[2]))), p)
-    val, back = Zygote.pullback(fobj, copy(ei0), copy(de0))
-    ḡei, ḡde = back(one(val))
-    ḡei === nothing && (ḡei = zero(ei0))       # objective may not depend on ∂ωε (n_eff) …
-    ḡde === nothing && (ḡde = zero(de0))       # … or on ε⁻¹
-    grad = J[1:N, :]' * vec(ḡei) .+ J[N+1:2N, :]' * vec(ḡde)
-    (val, grad)
+    F(q) = (d = diel_p(geomfn, matvals, minds, grid, q, om); fobj(d[1], d[2]))
+    g = Enzyme.gradient(_REVWP, F, p)
+    (g.val, g.derivs[1])
 end
 
-"Fundamental effective index n_eff(ε⁻¹) at frequency `om` (Zygote-differentiable via solve_k's
-adjoint). `warm` seeds nothing; kept simple for AD."
+"Fundamental effective index n_eff(ε⁻¹) at frequency `om` (Enzyme-differentiable via solve_k's
+adjoint rule)."
 neff_of(ei, om, grid, solver; k_tol=1e-9) = solve_k(om, ei, grid, solver; nev=1, k_tol=k_tol)[1][1] / om
 
 "Fundamental group index n_g(ε⁻¹, ∂ωε) at `om`."

--- a/examples/designer_dichroic_si3n4.jl
+++ b/examples/designer_dichroic_si3n4.jl
@@ -8,9 +8,9 @@
 # dichroic cutoff — and the crossing wavelength is tuned by the WGA width.
 #
 # The design DOF is the WGA width w_A. We minimise  L(w_A) = (n_A(λ_C, w_A) − n_B(λ_C))²  with
-# **OptiMode's automatic differentiation**: dn_A/dw_A is the hybrid ForwardDiff(geometry) ∘
-# Zygote(adjoint eigensolve) gradient, driving Adam. The optimum places β_A = β_B exactly at
-# the 1000-nm target.
+# **OptiMode's automatic differentiation**: dn_A/dw_A is a single Enzyme reverse-mode gradient
+# across the whole geometry→dielectric→eigensolve pipeline (`geom_value_grad`,
+# designer_common.jl), driving Adam. The optimum places β_A = β_B exactly at the 1000-nm target.
 #
 # Settings (see examples/README.md): --n-freqs (post-optimization crossing sweep, default 11),
 # --resolution-scale / --domain-scale (grid — kept small by default for fast AD).

--- a/examples/designer_dispersion_tantala_1p3um.jl
+++ b/examples/designer_dispersion_tantala_1p3um.jl
@@ -8,9 +8,9 @@
 #
 # The design DOF is the core cross-section (width, height) p = (w, h). We minimise
 # L(p) = β₂(p; 1.3 µm)²  with **OptiMode's automatic differentiation**: the geometry gradient of
-# β₂ keeps the high-dimensional geometry sensitivity as exact AD (hybrid ForwardDiff∘Zygote on
-# n_g) and finite-differences only the scalar ω-derivative (β₂ = ∂n_g/∂ω), per Gray, West & Ram
-# (2024). Adam then drives β₂ → 0 at 1.3 µm and the ZDW onto the target.
+# β₂ keeps the high-dimensional geometry sensitivity as exact Enzyme reverse-mode AD on n_g and
+# finite-differences only the scalar ω-derivative (β₂ = ∂n_g/∂ω), per Gray, West & Ram (2024).
+# Adam then drives β₂ → 0 at 1.3 µm and the ZDW onto the target.
 #
 # Settings (see examples/README.md): --n-freqs (post-optimization β₂(λ) sweep, default 9),
 # --resolution-scale / --domain-scale (grid — kept small by default for fast AD).

--- a/examples/designer_qpm_mgoln_1310.jl
+++ b/examples/designer_qpm_mgoln_1310.jl
@@ -9,8 +9,9 @@
 # The design degree of freedom is the rib top width w. First-order QPM needs
 #     n_SH(w) − n_FF(w) = λ_FF / (2 Λ_target).
 # We minimise  L(w) = (Δn(w) − λ_FF/(2Λ_target))²  with **OptiMode's automatic differentiation**:
-# dΔn/dw = dn_SH/dw − dn_FF/dw is the hybrid ForwardDiff(geometry)∘Zygote(adjoint eigensolve)
-# gradient (designer_common.jl), driving an Adam optimizer. No finite-difference geometry sweep.
+# dΔn/dw = dn_SH/dw − dn_FF/dw is a single Enzyme reverse-mode gradient across the whole
+# geometry→dielectric→eigensolve pipeline (`geom_value_grad`, designer_common.jl), driving an
+# Adam optimizer. No finite-difference geometry sweep.
 #
 # Settings (see examples/README.md): --n-freqs (post-optimization Δn(w) landscape sweep,
 # default 15), --resolution-scale / --domain-scale (grid — kept small by default for fast AD).

--- a/examples/remote_adjoint_optimization.jl
+++ b/examples/remote_adjoint_optimization.jl
@@ -13,8 +13,9 @@
 # background processes on one machine.
 
 using OptiMode
+using OptiMode.DielectricSmoothing.GeometryPrimitives: Cuboid
 using ModeSweeps
-using ForwardDiff
+using Enzyme
 using LinearAlgebra: dot
 
 const SETUP = joinpath(@__DIR__, "ridge_wg_setup.jl")
@@ -57,11 +58,26 @@ r = remote_value_and_gradient(SETUP, p, [1 / p.ω]; nev=1, name="adjoint_oneshot
 # `ε⁻¹_bar` is the sensitivity of the objective to every inverse-dielectric tensor entry
 # at every pixel. Chaining it with the (cheap, FFT-free) forward-mode geometry Jacobian
 # ∂ε⁻¹/∂(geometry) gives the exact geometry gradient — the eigensolve and its adjoint
-# stay on the cluster, only the smoothing Jacobian is differentiated locally.
+# stay on the cluster, only the smoothing Jacobian is differentiated locally (with Enzyme,
+# now that geometry-parameter gradients through `smooth_ε` are Enzyme-differentiable).
 #
 #   ∂neff/∂w_top = vec(ε⁻¹_bar) · ∂vec(ε⁻¹)/∂w_top
-geom_to_epsinv(w) = vec(make_problem((; p.ω, w_top=w, p.h_core)).ε⁻¹)   # ForwardDiff-friendly
-J = ForwardDiff.derivative(geom_to_epsinv, p.w_top)                     # ∂vec(ε⁻¹)/∂w_top
+#
+# `make_problem` itself calls `_f_ε_mats` (SymbolicUtils-backed) on every invocation, and
+# SymbolicUtils' internal expression cache is not Enzyme-differentiable (forward mode has no
+# rule for its `IdDict`-based memoization) — so unlike the designer scripts (which build the
+# material-value function *once*, outside the differentiated closure, via `matvals_builder`),
+# here we mirror `make_problem`'s geometry with the materials function precomputed the same way
+# before differentiating, keeping only the genuinely geometry-dependent part (shape → smooth_ε)
+# inside the Enzyme trace.
+const _fε_ridge, _ = _f_ε_mats([Si₃N₄, SiO₂], (:ω,))
+function geom_to_epsinv(w)
+    mat_vals = _fε_ridge([p.ω])
+    core = MaterialShape(Cuboid([0.0, 0.0], [w, p.h_core], [1.0 0.0; 0.0 1.0]), 1)
+    sm = smooth_ε((core,), mat_vals, (1, 2), Grid(6.0, 4.0, 128, 96))
+    vec(sliceinv_3x3(copy(selectdim(sm, 3, 1))))
+end
+J = Enzyme.jacobian(Enzyme.Forward, geom_to_epsinv, p.w_top)[1]         # ∂vec(ε⁻¹)/∂w_top
 ∂neff_∂w_top = dot(vec(g.ε⁻¹_bar), J)
 @info "geometry gradient (remote adjoint × local forward Jacobian)" ∂neff_∂w_top
 

--- a/lib/DielectricSmoothing/ext/DielectricSmoothingEnzymeExt.jl
+++ b/lib/DielectricSmoothing/ext/DielectricSmoothingEnzymeExt.jl
@@ -1,17 +1,28 @@
 # Enzyme.jl interface for DielectricSmoothing.
 #
-# `smooth_ε` now propagates a small 2nd-order Taylor jet (`J2`) through the closed-form
-# Kottke transforms (`kottke.jl`) instead of a giant symbolically-generated kernel, so
-# Enzyme differentiates the smoothing **material-data** gradients natively in both
-# directions — no custom rule needed for the kernel itself.
+# `smooth_ε` propagates a small 2nd-order Taylor jet (`J2`) through the closed-form Kottke
+# transforms (`kottke.jl`) instead of a giant symbolically-generated kernel, so Enzyme
+# differentiates the smoothing kernel **natively in both directions** — no custom rule needed
+# for the kernel itself, for *either* the material-data or the geometry-*parameter* gradient.
 #
-# The integer pixel bookkeeping (`corner_sinds`/`proc_sinds`/`matinds`) and the geometry
-# queries (`surfpt_nearby`/`volfrac`) are constant with respect to the material data, so
-# they are marked `EnzymeRules.inactive` — matching the `@non_differentiable` ChainRules
-# declarations used by Zygote. (Enzyme does not honour `@non_differentiable`; without these
-# markers it tries to differentiate the StaticArrays matrix inverse inside Cuboid
-# `surfpt_nearby`, which it cannot handle. Geometry-*parameter* gradients of `smooth_ε`
-# therefore still go through ForwardDiff/Mooncake, as before.)
+# The integer pixel bookkeeping (`corner_sinds`/`proc_sinds`/`matinds`) is piecewise-constant
+# (it returns which shape/material index owns a grid corner) — genuinely inactive w.r.t. *both*
+# material data and geometry parameters almost everywhere, matching the `@non_differentiable`
+# ChainRules declarations used by Zygote (Enzyme does not honour `@non_differentiable`, hence
+# these explicit markers).
+#
+# `surfpt_nearby`/`volfrac`/`_interface_geometry`, by contrast, carry the actual continuous
+# dependence of the smoothed dielectric on the *geometry* (they compute the interface location,
+# fill fraction and orientation Kottke averages over) — marking them inactive is only valid for
+# material-*data*-only differentiation, and silently gives a wrong all-zero geometry gradient
+# otherwise. They are deliberately left active here so Enzyme differentiates geometry parameters
+# too. Two historical blockers on this path are now resolved: (1) `Cuboid.surfpt_nearby` was
+# reworked (in the GeometryPrimitives fork) to avoid `inv(s.p)`, whose StaticArrays
+# implementation could crash Enzyme or yield silently wrong gradients; (2) the `Union` produced
+# by `shapes[sidx1]` indexing a heterogeneous shapes tuple inside `_interface_geometry` — which
+# used to raise `IllegalTypeAnalysisException` — no longer does with the pinned Enzyme version;
+# both the homogeneous- and heterogeneous-shape-type cases now match ForwardDiff/finite
+# differences exactly in forward and reverse mode (see `test/enzyme_geometry_gradient.jl`).
 
 module DielectricSmoothingEnzymeExt
 
@@ -23,13 +34,13 @@ using Enzyme: EnzymeRules
 EnzymeRules.inactive(::typeof(DielectricSmoothing.corner_sinds), args...; kwargs...) = nothing
 EnzymeRules.inactive(::typeof(DielectricSmoothing.proc_sinds), args...; kwargs...) = nothing
 EnzymeRules.inactive(::typeof(DielectricSmoothing.matinds), args...; kwargs...) = nothing
-EnzymeRules.inactive(::typeof(surfpt_nearby), args...; kwargs...) = nothing
-EnzymeRules.inactive(::typeof(volfrac), args...; kwargs...) = nothing
-# `_interface_geometry` indexes the heterogeneous shapes tuple (`shapes[sidx1]`), producing a
-# `Union` that Enzyme's strict type analysis cannot handle. It is constant w.r.t. the material
-# data (the differentiated input of `smooth_ε`), so marking it inactive keeps the Union out of
-# Enzyme's type analysis — fixing the `IllegalTypeAnalysisException` on the preallocated
-# `smooth_ε` assembly with Enzyme ≥ 0.13.168 on Julia 1.11.
-EnzymeRules.inactive(::typeof(DielectricSmoothing._interface_geometry), args...; kwargs...) = nothing
+
+# `Grid` is a fixed simulation-configuration struct (extents, point counts) — never itself a
+# differentiated quantity, however many closures happen to capture it. Declaring the whole type
+# inactive lets Enzyme's activity analysis skip it outright instead of inferring (sometimes
+# ambiguously, across nested closures that each capture the same `Grid`) that it needs a shadow,
+# which otherwise surfaces as `MethodError: no method matching zero(::Active{Grid{...}})` deep in
+# an imported ChainRules rule.
+EnzymeRules.inactive_type(::Type{<:DielectricSmoothing.Grid}) = true
 
 end # module

--- a/lib/DielectricSmoothing/test/runtests.jl
+++ b/lib/DielectricSmoothing/test/runtests.jl
@@ -211,6 +211,20 @@ end
         @test any(!iszero, gp_ref)
         @test all(isfinite, gp_ref)
         @test DI.gradient(loss_p, AutoForwardDiff(), p_geom0) ≈ gp_ref rtol = 1e-4
+
+        # Enzyme (fwd & rev) geometry gradient, on `ridge_wg`'s *heterogeneous* shapes tuple
+        # (Polygon + 2×Cuboid) — the case `_interface_geometry`'s `shapes[sidx1]` indexing used
+        # to raise `IllegalTypeAnalysisException` for, before `surfpt_nearby`/`volfrac`/
+        # `_interface_geometry` stopped being marked `EnzymeRules.inactive` (that marking is
+        # only valid for material-data-only differentiation; it silently zeroed geometry
+        # gradients otherwise). Now exact, matching ForwardDiff/finite differences.
+        for (name, backend) in (
+                ("Enzyme(reverse)", AutoEnzyme(; mode=set_runtime_activity(Enzyme.Reverse), function_annotation=Enzyme.Const)),
+                ("Enzyme(forward)", AutoEnzyme(; mode=set_runtime_activity(Enzyme.Forward), function_annotation=Enzyme.Const)))
+            @testset "$name" begin
+                @test DI.gradient(loss_p, backend, p_geom0) ≈ gp_ref rtol = 1e-4
+            end
+        end
     end
 
     @testset "geometry-parameter gradients (Kottke kernel)" begin
@@ -240,6 +254,13 @@ end
         @test any(!iszero, gk_ref)                            # nonzero edge sensitivity
         @test DI.gradient(kernel_geom, AutoForwardDiff(), pk0) ≈ gk_ref rtol = 1e-4
         @test DI.gradient(kernel_geom, AutoMooncake(; config=nothing), pk0) ≈ gk_ref rtol = 1e-4
+        for (name, backend) in (
+                ("Enzyme(reverse)", AutoEnzyme(; mode=Enzyme.Reverse, function_annotation=Enzyme.Const)),
+                ("Enzyme(forward)", AutoEnzyme(; mode=Enzyme.Forward, function_annotation=Enzyme.Const)))
+            @testset "$name" begin
+                @test DI.gradient(kernel_geom, backend, pk0) ≈ gk_ref rtol = 1e-4
+            end
+        end
     end
 
     @testset "smoothing geometry cache (SmoothingPlan)" begin


### PR DESCRIPTION
## Summary

- **Root cause fix**: `DielectricSmoothingEnzymeExt.jl` marked `surfpt_nearby`/`volfrac`/`_interface_geometry` as `EnzymeRules.inactive` to dodge an old Enzyme limitation (a `Union` type from indexing heterogeneous shape tuples used to crash Enzyme's type analysis). That marking is only valid for material-*data* differentiation — those functions carry the smoothed dielectric's actual *geometry* dependence, so marking them inactive silently returned a **zero gradient** for any geometry parameter (confirmed directly: Enzyme returned `0.0` where ForwardDiff/finite differences gave the correct nonzero value). Both historical blockers are already resolved with the pinned Enzyme version — `Cuboid.surfpt_nearby` no longer calls the problematic `inv()`, and the heterogeneous-tuple `Union` no longer raises `IllegalTypeAnalysisException`. Relaxing the markers (keeping only the genuinely constant integer bookkeeping — `corner_sinds`/`proc_sinds`/`matinds` — inactive) makes Enzyme match ForwardDiff/finite differences exactly, forward and reverse, for both homogeneous- and heterogeneous-shape-type geometries, at the same speed as before. **No GeometryPrimitives.jl changes were needed.**
- Also marks `Grid` as `EnzymeRules.inactive_type` (a fixed simulation-configuration struct, never itself differentiated) — fixes a separate `zero(::Active{Grid})` error surfacing from nested closures that each capture the same `Grid`.
- `examples/designer_common.jl`: `geom_value_grad` now computes the geometry gradient with a single `Enzyme.gradient(ReverseWithPrimal, ...)` call across the whole geometry→dielectric→eigensolve pipeline, replacing the ForwardDiff-Jacobian ∘ Zygote-adjoint hybrid scheme. All three designer scripts (QPM, dispersion, dichroic) reproduce their previous optimized designs **exactly**.
- `bragg_waveguide_period_adjoint.jl`: Zygote → Enzyme for `∂kz/∂Λ` (`solve_k_periodic` already carries an Enzyme rrule/frule).
- `remote_adjoint_optimization.jl`: the local geometry-Jacobian step now uses `Enzyme.jacobian` instead of `ForwardDiff.derivative`, with the materials function precomputed once outside the differentiated closure (SymbolicUtils' internal expression cache has no Enzyme forward rule). The remote SLURM deployment section itself hits an unrelated, pre-existing world-age bug in the local ModeSweeps worker path — untouched here.
- `ad_backend_benchmarks.jl`: added a geometry (Cuboid width) gradient benchmark entry across all backends, including Enzyme fwd/rev, to guard the fix going forward.
- New Enzyme forward/reverse regression tests in DielectricSmoothing's test suite: the full heterogeneous-shape-tuple pipeline (Polygon + 2×Cuboid) and the isolated Kottke-kernel geometry test, both matching finite differences.

Left unchanged (already Enzyme-compatible, not blocked by this issue — they differentiate material/temperature/angle parameters, not shape geometry): `tfln_shg_temperature_angle_ad.jl`, `tfln_bragg_waveguide_dispersion_adjoint.jl`.

## Testing

- `lib/DielectricSmoothing/test/runtests.jl`: 70 pass, 2 pre-existing broken (documented upstream Enzyme vacuum-column limitation, unrelated to this change).
- `lib/ModeAnalysis/test/runtests.jl`: 129 pass.
- All three designer scripts (`designer_qpm_mgoln_1310.jl`, `designer_dispersion_tantala_1p3um.jl`, `designer_dichroic_si3n4.jl`) re-run end-to-end; optimized designs match the previous hybrid-AD runs exactly.
- `bragg_waveguide_period_adjoint.jl` re-run: Enzyme adjoint matches finite difference to 5 significant figures.
- Standalone probes confirmed Enzyme geometry gradients match ForwardDiff/finite differences for both homogeneous (all-`Cuboid`) and heterogeneous (`Cuboid`+`Ball`) shape tuples, and for the full geometry→`smooth_ε`→`solve_k`→mode-quantity pipeline (both `group_index` and bare `neff`).

## Test plan
- [x] DielectricSmoothing test suite green (70 pass, 2 pre-existing broken)
- [x] ModeAnalysis test suite green (129 pass)
- [x] All 3 designer scripts reproduce prior optimized designs exactly
- [x] `bragg_waveguide_period_adjoint.jl` Enzyme adjoint vs. finite difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayn1B3fv797FbNBY2qiSXX)_