### PR TITLE
Dichroic designer: λC sweep + multi-material framework (Si3N4, X-cut LiNbO3/LiTaO3)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -122,11 +122,11 @@ the gap between them.
 - `ppln_thermal_tuning_han2026.jl` — electro-thermal QPM tuning companion to the above.
 
 ### EME reproductions + AD designers (share `eme_reproductions_common.jl` / `designer_common.jl`)
-- `dichroic_filter_magden2018.jl` — Si SOI thickness-contrast dichroic filter (Magden et al., Nat. Commun. 2018).
+- `dichroic_filter_magden2018.jl` — Si SOI solid-WGA/segmented-WGB dichroic filter (Magden et al., Nat. Commun. 2018).
 - `tfln_combiner_kwolek2026.jl` — TFLN >1-octave wavelength combiner (Kwolek et al., arXiv:2603.27034); see the dense-transmission note above.
 - `designer_qpm_mgoln_1310.jl` — AD-optimized χ² SHG QPM design, MgO:LiNbO₃ rib, new 1310→655 nm target.
 - `designer_dispersion_tantala_1p3um.jl` — AD-optimized zero-GVD design, Ta₂O₅ air-clad core, new 1.30 µm target.
-- `designer_dichroic_si3n4.jl` — AD-optimized EME dichroic cutoff, Si₃N₄ thickness-contrast coupler, new 1.00 µm target.
+- `designer_dichroic_si3n4.jl` — AD-optimized EME dichroic filter, Si₃N₄ solid-WGA/segmented-WGB coupler, new 1.00 µm target. Two-stage design: (1) AD-optimizes widths + rail gap for crossing at λ_C with maximum group-index mismatch (paper's sign), (2) EME search for the shortest adiabatic WGA–WGB gap-taper length.
 
 ### Dispersion-engineered PPLN (Jankowski et al., Optica 2020)
 - `tfln_ppln_jankowski2020.jl` / `tfln_ppln_jankowski2020_common.jl` — dispersion-engineered nanophotonic PPLN reproduction.

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,10 +30,36 @@ accuracy/speed experiment without editing source.
 | `n_dense`            | `--n-dense=N`              | `OPTIMODE_N_DENSE`           | varies  | Number of points in a *cheap, closed-form* dense curve (interpolated transmission, analytic gain/QPM-mismatch spectra) — free to make large; only affects plot smoothness. |
 | `n_eme_freqs`        | `--n-eme-freqs=N`          | `OPTIMODE_N_EME_FREQS`       | `15`    | Number of wavelengths for a genuinely EME-solved (`eme`/`power_coupling`) dense transmission overlay, where an example provides one (currently `tfln_combiner_kwolek2026.jl`). |
 | `n_cells`            | `--n-cells=N`              | `OPTIMODE_N_CELLS`           | `6`     | Number of cells in an EME cascade. |
+| `quality`            | `--quality=X`              | `OPTIMODE_QUALITY`           | `medium` | Bundled `low`/`medium`/`high`/`ultra` preset for `resolution_scale`/`domain_scale`/`n_cells` together — see below. |
 | `run_mode`           | `--run-mode=local\|slurm`  | `OPTIMODE_RUN_MODE`          | `local` | See [Local vs. SLURM](#local-vs-slurm) below. |
 | `slurm`              | *(keyword only)*           | —                            | `nothing` | A `ModeSweeps.SlurmConfig`; only settable as an `example_settings(slurm=...)` keyword (it has too many sub-fields for a single flag/env var) — see `remote_mode_solve.jl`. |
 
 `--help` / `-h` on any of these scripts prints the same reference table and exits.
+
+#### Bundled `quality` presets
+
+`resolution_scale`, `domain_scale`, and `n_cells` — grid resolution, how far the simulation
+boundary sits from the waveguide core, and EME cascade cell count — can be set individually
+(the table above), or all at once with a `quality` preset:
+
+| `quality` | `resolution_scale` | `domain_scale` | `n_cells` |
+|-----------|---------------------|----------------|-----------|
+| `low`     | `0.5`               | `0.8`          | `3`       |
+| `medium`  | `1.0`               | `1.0`          | `6`       |
+| `high`    | `1.5`               | `1.2`          | `10`      |
+| `ultra`   | `2.5`               | `1.5`          | `16`      |
+
+Precedence for each of those three settings is (highest wins): CLI flag > env var > script's own
+`example_settings(...)` keyword > `quality` preset > built-in hardcoded default. So a script that
+passes its own tuned `resolution_scale`/`domain_scale`/`n_cells` keyword still wins over the
+preset (the preset only fills in values a script left unset), but any script can be bumped up or
+down from the command line with e.g. `--quality=high` or `OPTIMODE_QUALITY=ultra`, without
+touching source:
+
+```sh
+julia --project=. examples/designer_dichroic_si3n4.jl --quality=high
+OPTIMODE_QUALITY=low julia --project=. examples/designer_dichroic_linbo3_litao3.jl   # quick smoke test
+```
 
 Every script prints its resolved settings on startup, e.g.:
 
@@ -126,7 +152,9 @@ the gap between them.
 - `tfln_combiner_kwolek2026.jl` — TFLN >1-octave wavelength combiner (Kwolek et al., arXiv:2603.27034); see the dense-transmission note above.
 - `designer_qpm_mgoln_1310.jl` — AD-optimized χ² SHG QPM design, MgO:LiNbO₃ rib, new 1310→655 nm target.
 - `designer_dispersion_tantala_1p3um.jl` — AD-optimized zero-GVD design, Ta₂O₅ air-clad core, new 1.30 µm target.
-- `designer_dichroic_si3n4.jl` — AD-optimized EME dichroic filter, Si₃N₄ solid-WGA/segmented-WGB coupler, new 1.00 µm target. Two-stage design: (1) AD-optimizes widths + rail gap for crossing at λ_C with maximum group-index mismatch (paper's sign), (2) EME search for the shortest adiabatic WGA–WGB gap-taper length.
+- `dichroic_designer_common.jl` — shared two-stage AD+EME dichroic-filter driver (`DichroicGeometry`, `run_dichroic_case`, `run_dichroic_sweep`) used by both designer scripts below: per-`(geometry, λ_C target)` case, AD-optimizes widths (+ rail gap) for crossing at λ_C with maximum group-index mismatch (paper's sign), EME-searches the shortest adiabatic WGA–WGB gap-taper length, computes a dense broadband transmission spectrum and TE00 field profiles (red-detuned/cutoff/blue-detuned), and saves a combined per-case report PNG + trace CSV; `run_dichroic_sweep` then sweeps an array of λ_C targets and saves one summary grid PNG (matching wavelength axes, λ_C target as a vertical dashed line) + one sweep-summary CSV per geometry.
+- `designer_dichroic_si3n4.jl` — Si₃N₄ solid-WGA/segmented-WGB coupler (buried in SiO₂), swept over λ_C = 1.00–1.50 µm (11 targets, 50 nm step) × 6 core thicknesses (40/60/80/100/200/400 nm). Thin cores need much wider (3–10 µm) structures and a wider/finer grid to get a usable group-index mismatch — see the script header.
+- `designer_dichroic_linbo3_litao3.jl` — X-cut TFLN/TFLT rib-on-slab coupler (65° sidewalls via `GeometryPrimitives.Trapezoid`, fully encapsulated in SiO₂), swept over the same λ_C array × 3 (full thickness, slab thickness) stacks (400/100, 500/150, 600/200 nm) × {LiNbO₃, LiTaO₃}.
 
 ### Dispersion-engineered PPLN (Jankowski et al., Optica 2020)
 - `tfln_ppln_jankowski2020.jl` / `tfln_ppln_jankowski2020_common.jl` — dispersion-engineered nanophotonic PPLN reproduction.

--- a/examples/designer_dichroic_linbo3_litao3.jl
+++ b/examples/designer_dichroic_linbo3_litao3.jl
@@ -1,0 +1,92 @@
+# AD+EME DESIGNER — spectrally-selective dichroic filter on X-cut TFLN/TFLT rib waveguides,
+# swept over cutoff wavelength and over three (full-thickness, slab-thickness) film stacks.
+#
+# Same mode-crossing / dichroic-filter methodology as designer_dichroic_si3n4.jl (Magden et al.,
+# Nat. Commun. 9, 3009 (2018)) and the same shared two-stage AD+EME driver
+# (dichroic_designer_common.jl), applied to a **rib-on-slab** waveguide family instead of a
+# buried strip: X-cut thin-film LiNbO₃ (TFLN) and X-cut thin-film LiTaO₃ (TFLT), fully
+# encapsulated in SiO₂, with a 65° sidewall (`GeometryPrimitives.Trapezoid`, the same rib profile
+# used descriptively — but not previously actually built with sloped sidewalls — in
+# tfln_combiner_kwolek2026.jl).
+#
+# Film stacks (full thickness / slab thickness, all a 300-nm etch): 400/100, 500/150, 600/200 nm.
+# WGA is a single solid-core rib of top-etch base width w_A atop the shared slab; WGB is the same
+# paper-Fig.-1b sub-wavelength segmentation as the Si₃N₄ designer — three rib segments of base
+# width w_B, gap g_B — atop the *same* continuous slab (so WGA and WGB differ only in their
+# above-slab core geometry, exactly mirroring the paper's "same material and thickness" WGB
+# construction). X-cut orientation (extraordinary axis in-plane along x) is the standard
+# TFLN/TFLT convention used throughout this package's other TFLN/TFLT examples (see
+# tfln_shg_dispersion.jl, pplt_allband_opa_kuznetsov2026.jl): `rotate(LiNbO₃, Ry)`.
+#
+# Same design sign convention as designer_dichroic_si3n4.jl (n_gA > n_gB at the crossing) and
+# the same two-phase AD warm start / EME adiabatic-taper-length search / dense-spectrum / TE00
+# field-profile pipeline — see dichroic_designer_common.jl and designer_dichroic_si3n4.jl headers
+# for the physics. Unlike the Si₃N₄ designer's thin-core regime, TFLN/TFLT ribs at these
+# thicknesses (400–600 nm) are comparable in scale to this package's other TFLN rib examples
+# (~1–2 µm top width), so the design-space bounds below are NOT thickness-dependent.
+#
+# Settings (see examples/README.md): --n-freqs (dispersion/spectrum sweep nodes, default 11),
+# --n-dense (dense spectrum resolution, default 400), --resolution-scale/--domain-scale/--n-cells
+# or the bundled --quality=low|medium|high|ultra preset (grid + EME taper cell count).
+#
+# Run:  julia --project=. examples/designer_dichroic_linbo3_litao3.jl        (needs CairoMakie)
+#       julia --project=. examples/designer_dichroic_linbo3_litao3.jl --quality=high
+
+include(joinpath(@__DIR__, "dichroic_designer_common.jl"))
+using OptiMode: rotate
+using OptiMode.DielectricSmoothing.GeometryPrimitives: Trapezoid
+using CairoMakie
+
+cfg = example_settings(n_freqs=11, n_dense=400)
+solver = KrylovKitEigsolve()
+λC_grid = collect(1.00:0.05:1.50)                       # 11 targets, 1000–1500 nm
+stacks_nm = ((400, 100), (500, 150), (600, 200))         # (full thickness, slab thickness)
+θ_sidewall = deg2rad(65.0)                                # 65° sidewall (base-to-wall angle)
+SUBW = 60.0                                                # slab/substrate half-plane extent (µm), ≫ domain
+
+const _RY = [0.0 0.0 1.0; 0.0 1.0 0.0; -1.0 0.0 0.0]      # RotY(π/2): c-axis (z) → in-plane x
+LiNbO₃_xcut = rotate(LiNbO₃, _RY; name=:LiNbO₃_xcut)
+LiTaO₃_xcut = rotate(LiTaO₃, _RY; name=:LiTaO₃_xcut)
+# `mv` built at top level (once per material) — see DichroicGeometry docstring for why.
+mv_LN = matvals_builder([LiNbO₃_xcut, SiO₂]; air=false)
+mv_LT = matvals_builder([LiTaO₃_xcut, SiO₂]; air=false)
+
+"Design-space starting point + box bounds (µm) for a TFLN/TFLT rib: (w_A, w_B, g_B), base
+(bottom-of-etch) widths/gap — thickness-independent at these (400–600 nm) film thicknesses."
+tfln_geometry_defaults() = (p0=[1.20, 0.60, 0.30], lo=[0.80, 0.40, 0.20], hi=[1.80, 1.00, 0.60])
+
+"Build the DichroicGeometry (rib-on-slab WGA / 3-rib segmented WGB, 65° sidewalls) for one
+`(core_material, full_thickness_nm, slab_thickness_nm)` TFLN/TFLT stack."
+function tfln_geometry(core_mat, mv, tag_prefix, full_nm, slab_nm, cfg)
+    full, slab = 1e-3 * full_nm, 1e-3 * slab_nm
+    etch = full - slab
+    mats = (core_mat, SiO₂)
+    ridge(cx, w_base) = MaterialShape(Trapezoid([cx, slab], w_base, etch, θ_sidewall), 1)
+    slab_shape = MaterialShape(Cuboid([0.0, slab/2], [SUBW, slab], [1.0 0.0; 0.0 1.0]), 1)
+    wgA_shapes(p) = (ridge(0.0, p[1]), slab_shape)
+    wgB_shapes(p) = (w = p[2]; g = p[3]; (ridge(-(w + g), w), ridge(0.0, w), ridge(w + g, w), slab_shape))
+    function coupled_shapes(p, gap)
+        w_A, w_B, g_B = p
+        xA, xB = -(gap/2 + w_A/2), gap/2 + w_B/2
+        (ridge(xA, w_A), ridge(xB, w_B), ridge(xB + w_B + g_B, w_B), ridge(xB + 2*(w_B + g_B), w_B), slab_shape)
+    end
+    d = tfln_geometry_defaults()
+    grid = mk_grid(cfg, 7.0, 3.0, 112, 58)
+    DichroicGeometry(; tag=@sprintf("%s_full%03d_slab%03dnm", tag_prefix, full_nm, slab_nm), mats, mv,
+        wgA_shapes, wgB_shapes, coupled_shapes,
+        mindsA=(1, 1, 2), mindsB=(1, 1, 1, 1, 2), mindsAB=(1, 1, 1, 1, 1, 2), grid,
+        p0=d.p0, lo=d.lo, hi=d.hi, g_start=0.40, g_end=2.50)
+end
+
+println("== X-cut TFLN/TFLT dichroic designer: λ_C ∈ [", λC_grid[1], ", ", λC_grid[end],
+        "] µm × stacks ", stacks_nm, " (65° sidewall) ==")
+all_results = Dict{String,Any}()
+for (mat, mv, tag) in ((LiNbO₃_xcut, mv_LN, "LiNbO3"), (LiTaO₃_xcut, mv_LT, "LiTaO3"))
+    for (full_nm, slab_nm) in stacks_nm
+        @printf("\n---- %s full=%d nm slab=%d nm (etch=%d nm) ----\n", tag, full_nm, slab_nm, full_nm - slab_nm)
+        geo = tfln_geometry(mat, mv, tag, full_nm, slab_nm, cfg)
+        all_results[geo.tag] = run_dichroic_sweep(geo, λC_grid, cfg, solver; xlims=(0.6, 1.9))
+    end
+end
+println("\ndone: 2 materials × ", length(stacks_nm), " stacks × ", length(λC_grid), " cutoff targets → ",
+        2 * length(stacks_nm) * length(λC_grid), " cases. Summary grids + CSVs → ", OUTDIR)

--- a/examples/designer_dichroic_si3n4.jl
+++ b/examples/designer_dichroic_si3n4.jl
@@ -1,78 +1,193 @@
 # AD-driven DESIGNER — spectrally-selective EME dichroic filter on a NEW stack and NEW target.
 #
-# Applies the mode-crossing / dichroic-filter workflow of the reproduction example
-# (dichroic_filter_magden2018.jl) to a user-controlled **Si₃N₄-on-SiO₂** stack (instead of Si
-# SOI) and a NEW cutoff target in the near-IR: **λ_C = 1000 nm**. Dissimilar guides are made by
-# thickness contrast (as in the MEOW fork's dichroic_designer_si3n4_thickness): a thick-narrow
-# WGA (t_A = 400 nm) coupled to a thin-wide WGB (t_B = 200 nm). Their n_eff(λ) cross once — the
-# dichroic cutoff — and the crossing wavelength is tuned by the WGA width.
+# Applies the mode-crossing / dichroic-filter design methodology of Magden et al., "Transmissive
+# silicon photonic dichroic filters with spectrally selective waveguides," Nat. Commun. 9, 3009
+# (2018) — reproduced on Si SOI in dichroic_filter_magden2018.jl — to a user-controlled
+# **Si₃N₄-on-SiO₂** stack and a NEW cutoff target: **λ_C = 1000 nm**.
 #
-# The design DOF is the WGA width w_A. We minimise  L(w_A) = (n_A(λ_C, w_A) − n_B(λ_C))²  with
-# **OptiMode's automatic differentiation**: dn_A/dw_A is a single Enzyme reverse-mode gradient
-# across the whole geometry→dielectric→eigensolve pipeline (`geom_value_grad`,
-# designer_common.jl), driving Adam. The optimum places β_A = β_B exactly at the 1000-nm target.
+# Dissimilar guides are made exactly as in the paper's Fig. 1b cross-section (not by thickness
+# contrast): a solid strip **WGA** (width w_A) next to a sub-wavelength segmented **WGB** — three
+# solid rail segments of width w_B separated by gaps g_B, same material and thickness as WGA.
+# "This idea of mimicking a continuous waveguide using segments smaller than the wavelength is
+# similar to a sub-wavelength grating... we independently engineer the effective and group
+# indices... by controlling the widths and separations of individual segments" (§Coupled-mode
+# description). The segmented WGB behaves like a lower-index, lower-group-index waveguide than
+# the solid WGA — the paper states this is "essential for a good extinction ratio between the
+# two output ports," since phase matching at a single λ_C together with a *large* group-index
+# mismatch elsewhere is what gives a sharp, well-defined cutoff (§Power roll-off).
+#
+# ── Design sign convention (from the paper) ──────────────────────────────────────────────────
+# Fig. 2a: "δ(λ < λ_C) > 0 and δ(λ > λ_C) < 0" for δ = β_A − β_B. Since dβ/dλ = −2π n_g/λ² < 0,
+# a *decreasing* δ(λ) (as here) means d(β_A−β_B)/dλ ∝ −(n_gA − n_gB) < 0, i.e. **n_gA > n_gB** —
+# consistent with "WGB possesses spectral characteristics equivalent to a waveguide with a
+# smaller refractive index core, resulting in a smaller group index" (§Coupled-mode description).
+# We therefore reward designs with n_gA − n_gB > 0, matching the paper's sign.
+#
+# ── Stage 1: phase-matching + maximum group-index mismatch (AD, Enzyme) ──────────────────────
+# Design DOF p = (w_A, w_B, g_B). Minimise
+#   L₁(p) = (n_A(λ_C,p) − n_B(λ_C,p))² − β·(n_gA(λ_C,p) − n_gB(λ_C,p))
+# with **OptiMode's automatic differentiation**: each of n_A, n_B, n_gA, n_gB and their p-gradients
+# come from a single Enzyme reverse-mode pass across the geometry→dielectric→eigensolve pipeline
+# (`geom_value_grad`, designer_common.jl). Minimizing L₁ drives the crossing to λ_C while, among
+# the crossing-satisfying designs, preferring the largest group-index mismatch in the paper's
+# sign — i.e. the sharpest, most clearly-defined single-wavelength cutoff.
+#
+# ── Stage 2: adiabatic taper length (EME) ────────────────────────────────────────────────────
+# With the optimized cross-section fixed, build the actual two-waveguide coupled structure and
+# an EME cascade of `cfg.n_cells` cells over which the WGA–WGB edge gap widens from a strongly-
+# coupled interaction value to a well-separated output value (the paper's "section ③"). We
+# search for the *shortest* taper length whose EME-computed quasi-even → quasi-odd mode mixing
+# (`power_coupling`, the exact non-adiabatic loss) stays below a target at both a short-pass and
+# a long-pass test wavelength — i.e. the shortest adiabatic (low-loss) transition, following the
+# paper's own Fig. 3b–d methodology of choosing section lengths from transmission-vs-length
+# curves.
 #
 # Settings (see examples/README.md): --n-freqs (post-optimization crossing sweep, default 11),
-# --resolution-scale / --domain-scale (grid — kept small by default for fast AD).
+# --n-cells (EME taper cell count, default 6), --resolution-scale / --domain-scale (grid).
 #
 # Run:  julia --project=. examples/designer_dichroic_si3n4.jl   (needs CairoMakie)
-#       julia --project=. examples/designer_dichroic_si3n4.jl --resolution-scale=2
+#       julia --project=. examples/designer_dichroic_si3n4.jl --resolution-scale=1.5
 
 include(joinpath(@__DIR__, "designer_common.jl"))
+include(joinpath(@__DIR__, "eme_reproductions_common.jl"))
 using CairoMakie
 
-cfg = example_settings(n_freqs=11)
+cfg = example_settings(n_freqs=11, n_cells=6)
 solver = KrylovKitEigsolve()
 λC_target = 1.00                              # NEW cutoff target (µm)
-tA, tB = 0.40, 0.20                           # WGA thick / WGB thin Si₃N₄ (thickness-contrast)
-wB = 1.10                                      # WGB fixed width (thin, wide)
+t = 0.40                                       # uniform Si₃N₄ thickness for WGA & WGB (µm)
 mats = [Si₃N₄, SiO₂]
 mv = matvals_builder(mats; air=false)         # Si₃N₄ cores buried in SiO₂
-grid = mk_grid(cfg, 5.0, 3.0, 40, 30)
+grid = mk_grid(cfg, 6.0, 3.0, 48, 30)
+om_C = 1 / λC_target
 
-wgA(w) = (MaterialShape(Cuboid([0.0, 0.0], [w[1], tA], [1.0 0.0; 0.0 1.0]), 1),)
-wgB     = (MaterialShape(Cuboid([0.0, 0.0], [wB, tB], [1.0 0.0; 0.0 1.0]), 1),)
-mindsA = (1, 2); mindsB = (1, 2)
+# --- geometry: solid WGA vs. 3-segment (rail) WGB, both isolated for stage 1 ------------------
+rail(cx, w) = MaterialShape(Cuboid([cx, 0.0], [w, t], [1.0 0.0; 0.0 1.0]), 1)
+wgA_shapes(p) = (rail(0.0, p[1]),)                                    # solid WGA, width p[1]
+wgB_shapes(p) = (w = p[2]; g = p[3]; (rail(-(w + g), w), rail(0.0, w), rail(w + g, w)))  # 3-rail WGB
+mindsA = (1, 2); mindsB = (1, 1, 1, 2)
 
-nA_of(w, λ) = neff_of(diel_p(wgA, mv, mindsA, grid, w, 1/λ)[1], 1/λ, grid, solver)
-nB_of(λ)    = neff_of(diel_p((_)->wgB, mv, mindsB, grid, [0.0], 1/λ)[1], 1/λ, grid, solver)
+nA_of(p, λ) = neff_of(diel_p(wgA_shapes, mv, mindsA, grid, p, 1/λ)[1], 1/λ, grid, solver)
+nB_of(p, λ) = neff_of(diel_p(wgB_shapes, mv, mindsB, grid, p, 1/λ)[1], 1/λ, grid, solver)
 
-nB_target = nB_of(λC_target)
-"Loss and AD gradient of L(w_A) = (n_A(λ_C, w_A) − n_B(λ_C))²."
-function loss_grad(w)
-    nA, gA = geom_value_grad((ei, de) -> neff_of(ei, 1/λC_target, grid, solver), wgA, mv, mindsA, grid, w, 1/λC_target)
-    r = nA - nB_target
-    (r^2, 2r .* gA)
+# --- Stage 1: AD-optimize p=(w_A, w_B, g_B) for crossing at λ_C + max n_gA−n_gB ---------------
+# A single soft-penalty loss r² − β·Δn_g has a structural equilibrium bias: near the crossing
+# (r→0) the r² gradient vanishes while the constant −β·∇Δn_g term does not, so a fixed-β run
+# settles at some small but nonzero r rather than the crossing itself. We instead warm-start in
+# two phases — (1a) minimize the crossing condition alone (β=0) to lock onto λ_C precisely, then
+# (1b) a short, small-step refinement of the *combined* loss from that crossing, which nudges
+# Δn_g in the paper's sign without re-opening the gap. Both phases share the same AD machinery.
+const β_gvm = 0.002
+lo1, hi1 = [0.20, 0.10, 0.10], [0.40, 0.18, 0.18]
+"Loss and Enzyme gradient of the pure crossing condition L(p) = (n_A−n_B)² at λ_C."
+function loss_grad_crossing(p)
+    nA, gnA = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgA_shapes, mv, mindsA, grid, p, om_C)
+    nB, gnB = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgB_shapes, mv, mindsB, grid, p, om_C)
+    r = nA - nB
+    (r^2, 2r .* (gnA .- gnB))
+end
+"Loss and Enzyme gradient of L₁(p) = (n_A−n_B)² − β·(n_gA−n_gB) at λ_C."
+function loss_grad_stage1(p)
+    nA, gnA   = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgA_shapes, mv, mindsA, grid, p, om_C)
+    nB, gnB   = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgB_shapes, mv, mindsB, grid, p, om_C)
+    ngA, gngA = geom_value_grad((ei, de) -> ng_of(ei, de, om_C, grid, solver), wgA_shapes, mv, mindsA, grid, p, om_C)
+    ngB, gngB = geom_value_grad((ei, de) -> ng_of(ei, de, om_C, grid, solver), wgB_shapes, mv, mindsB, grid, p, om_C)
+    r = nA - nB
+    L = r^2 - β_gvm * (ngA - ngB)
+    g = 2r .* (gnA .- gnB) .- β_gvm .* (gngA .- gngB)
+    (L, g)
 end
 
-w0 = [0.45]
-@printf("== dichroic designer: Si₃N₄ thickness-contrast coupler, cutoff target λ_C=%.0f nm ==\n", 1e3λC_target)
-@printf("WGB (t=%.0f nm, w=%.2f µm): n_B(λ_C)=%.4f\n", 1e3tB, wB, nB_target)
-@printf("start w_A=%.3f µm: n_A(λ_C)=%.4f\n", w0[1], nA_of(w0, λC_target))
-res = optimize_design(loss_grad, w0; lo=[0.30], hi=[1.20], iters=18, lr=0.02)
-wA★ = res.p[1]
-@printf("optimized w_A=%.3f µm: n_A(λ_C)=%.4f  (n_B=%.4f)\n", wA★, nA_of([wA★], λC_target), nB_target)
+p0 = [0.28, 0.14, 0.12]                      # start: w_A, w_B(seg), g_B(rail gap) [µm]
+@printf("== dichroic designer: Si₃N₄ solid-WGA / segmented-WGB, cutoff target λ_C=%.0f nm ==\n", 1e3λC_target)
+@printf("start (w_A,w_B,g_B)=(%.3f,%.3f,%.3f) µm: n_A=%.4f n_B=%.4f\n",
+        p0..., nA_of(p0, λC_target), nB_of(p0, λC_target))
+println("-- phase 1a: lock the crossing (β=0) --")
+res0 = optimize_design(loss_grad_crossing, p0; lo=lo1, hi=hi1, iters=40, lr=0.01)
+println("-- phase 1b: refine for max Δn_g near the crossing (small steps) --")
+res1 = optimize_design(loss_grad_stage1, res0.p; lo=lo1, hi=hi1, iters=12, lr=0.002)
+p★ = res1.p
+w_A★, w_B★, g_B★ = p★
+nA★, ngA★ = nA_of(p★, λC_target), ng_of(diel_p(wgA_shapes, mv, mindsA, grid, p★, om_C)[1:2]..., om_C, grid, solver)
+nB★, ngB★ = nB_of(p★, λC_target), ng_of(diel_p(wgB_shapes, mv, mindsB, grid, p★, om_C)[1:2]..., om_C, grid, solver)
+@printf("optimized (w_A,w_B,g_B)=(%.3f,%.3f,%.3f) µm: n_A=%.4f n_B=%.4f  n_gA-n_gB=%+.3f (paper sign: >0)\n",
+        p★..., nA★, nB★, ngA★ - ngB★)
 
-# --- dispersion crossing before / after + cutoff ---------------------------------------
+# --- dispersion crossing before / after --------------------------------------------------------
 λs = collect(range(0.80, 1.30; length=cfg.n_freqs))
-nB = [nB_of(λ) for λ in λs]
-nA0 = [nA_of(w0, λ) for λ in λs]
-nA★ = [nA_of([wA★], λ) for λ in λs]
-xcross(nA_) = (d = nA_ .- nB; for i in 1:length(λs)-1; sign(d[i]) != sign(d[i+1]) && return λs[i]-d[i]*(λs[i+1]-λs[i])/(d[i+1]-d[i]); end; NaN)
-λC0, λC★ = xcross(nA0), xcross(nA★)
+nA0, nB0 = [nA_of(p0, λ) for λ in λs], [nB_of(p0, λ) for λ in λs]
+nA1, nB1 = [nA_of(p★, λ) for λ in λs], [nB_of(p★, λ) for λ in λs]
+λC0, λC★ = crossing_wavelength(λs, nA0, nB0), crossing_wavelength(λs, nA1, nB1)
 @printf("cutoff: start λ_C=%s µm → optimized λ_C=%s µm (target %.3f)\n",
-        isnan(λC0) ? "—" : string(round(λC0,digits=3)), isnan(λC★) ? "—" : string(round(λC★,digits=3)), λC_target)
+        isnan(λC0) ? "—" : string(round(λC0, digits=3)), isnan(λC★) ? "—" : string(round(λC★, digits=3)), λC_target)
 
-fig = Figure(size=(920, 340))
-ax1 = Axis(fig[1, 1], xlabel="Adam iteration", ylabel="loss (n_A − n_B)²",
-    title=@sprintf("AD-optimized dichroic cutoff (Si₃N₄, %.0f nm)", 1e3λC_target), yscale=log10)
-lines!(ax1, 1:length(res.history), res.history, color=:crimson, linewidth=2)
-ax2 = Axis(fig[1, 2], xlabel="wavelength (µm)", ylabel="effective index",
+# --- Stage 2: EME adiabatic taper — shortest length keeping mode-mixing loss low --------------
+println("== Stage 2: EME adiabatic taper length search (WGA–WGB coupling gap) ==")
+g_start, g_end = 0.30, 2.00                    # coupled (interaction) → separated (output) gap [µm]
+
+"Coupled 4-shape (WGA + 3-segment WGB) cross-section at WGA–WGB edge-to-edge gap `gap`."
+function coupled_shapes(gap)
+    xA = -(gap / 2 + w_A★ / 2)
+    xB = gap / 2 + w_B★ / 2
+    (rail(xA, w_A★), rail(xB, w_B★), rail(xB + w_B★ + g_B★, w_B★), rail(xB + 2 * (w_B★ + g_B★), w_B★))
+end
+minds_AB = (1, 1, 1, 1, 2)
+
+"Non-adiabatic loss (quasi-even → quasi-odd mode mixing) of a K-cell, length-`L` gap taper at ω."
+function adiabatic_loss(L, ω; K=cfg.n_cells)
+    edges = collect(range(0.0, L; length=K + 1))
+    gaps = collect(range(g_start, g_end; length=K))
+    cells = [Cell(i, (edges[i]+edges[i+1])/2, edges[i+1]-edges[i],
+                  CrossSection(collect(MaterialShape, coupled_shapes(gaps[i])), collect(Int, minds_AB)))
+             for i in 1:K]
+    res = eme(cells, mats, ω, grid, solver; nev=2, k_tol=1e-7)
+    power_coupling(res; in_mode=1, out_mode=2)
+end
+
+λ_short, λ_long = λC_target - 0.15, λC_target + 0.15
+# Loss decreases with L as expected for an adiabatic transition, but is not perfectly monotonic
+# at very long L (nev=2 mode tracking becomes less reliable over many cells); `findfirst` below
+# only needs the *first* L meeting tolerance, so this doesn't affect the reported L★.
+Ls = [5.0, 10.0, 20.0, 40.0, 80.0, 160.0, 320.0, 640.0]
+losses = Float64[]
+for L in Ls
+    ℓ = max(adiabatic_loss(L, 1/λ_short), adiabatic_loss(L, 1/λ_long))
+    push!(losses, ℓ)
+    @printf("  L=%6.1f µm  max(mode-mixing loss)=%.4e\n", L, ℓ)
+    flush(stdout)
+end
+adiabatic_tol = 0.01
+i_ok = findfirst(≤(adiabatic_tol), losses)
+L★ = i_ok === nothing ? Ls[end] : Ls[i_ok]
+@printf("shortest adiabatic taper (loss ≤ %.0e): L★ = %.1f µm%s\n",
+        adiabatic_tol, L★, i_ok === nothing ? "  (tolerance not reached within Ls — using longest tested)" : "")
+
+# --- plots ------------------------------------------------------------------------------------
+fig1 = Figure(size=(920, 340))
+ax1 = Axis(fig1[1, 1], xlabel="Adam iteration", ylabel="loss  (log scale)", yscale=log10,
+    title=@sprintf("Stage 1: AD-optimized crossing + max Δn_g (Si₃N₄, %.0f nm)", 1e3λC_target))
+lines!(ax1, 1:length(res0.history), max.(res0.history, 1e-12), color=:dodgerblue, linewidth=2, label="1a: (n_A−n_B)²")
+lines!(ax1, length(res0.history) .+ (1:length(res1.history)), max.(abs.(res1.history), 1e-12),
+    color=:crimson, linewidth=2, label="1b: |(n_A−n_B)² − β·Δn_g|  (loss is negative ⇒ Δn_g improving)")
+vlines!(ax1, [length(res0.history) + 0.5], color=:gray, linestyle=:dot)
+axislegend(ax1, position=:rt, labelsize=9)
+ax2 = Axis(fig1[1, 2], xlabel="wavelength (µm)", ylabel="effective index",
     title="WGA/WGB mode crossing: start vs optimized")
-lines!(ax2, λs, nB, color=:black, linewidth=2, label="WGB (fixed)")
+lines!(ax2, λs, nB0, color=:black, linewidth=2, linestyle=:dash, label="WGB start")
 lines!(ax2, λs, nA0, color=:dodgerblue, linewidth=2, linestyle=:dash, label="WGA start")
-lines!(ax2, λs, nA★, color=:crimson, linewidth=2, label="WGA optimized")
+lines!(ax2, λs, nB1, color=:gray30, linewidth=2, label="WGB optimized")
+lines!(ax2, λs, nA1, color=:crimson, linewidth=2, label="WGA optimized")
 vlines!(ax2, [λC_target], color=:gray, linestyle=:dot)
-axislegend(ax2, position=:rt)
-save(joinpath(OUTDIR, "designer_dichroic_si3n4.png"), fig)
-println("saved: designer_dichroic_si3n4.png → ", OUTDIR)
+axislegend(ax2, position=:rt, labelsize=10)
+save(joinpath(OUTDIR, "designer_dichroic_si3n4_stage1.png"), fig1)
+
+fig2 = Figure(size=(560, 380))
+ax3 = Axis(fig2[1, 1], xlabel="taper length L (µm)", ylabel="quasi-even → quasi-odd mode mixing",
+    title="Stage 2: adiabatic taper length search (EME)", xscale=log10, yscale=log10)
+scatterlines!(ax3, Ls, max.(losses, 1e-12), color=:seagreen, linewidth=2, marker=:circle)
+hlines!(ax3, [adiabatic_tol], color=:gray, linestyle=:dash, label=@sprintf("tolerance %.0e", adiabatic_tol))
+vlines!(ax3, [L★], color=:crimson, linestyle=:dot, label=@sprintf("L★=%.0f µm", L★))
+axislegend(ax3, position=:rt)
+save(joinpath(OUTDIR, "designer_dichroic_si3n4_stage2.png"), fig2)
+
+println("saved: designer_dichroic_si3n4_stage1.png, designer_dichroic_si3n4_stage2.png → ", OUTDIR)

--- a/examples/designer_dichroic_si3n4.jl
+++ b/examples/designer_dichroic_si3n4.jl
@@ -28,12 +28,14 @@
 # ── Thin-core caveat ──────────────────────────────────────────────────────────────────────────
 # As the Si₃N₄ core thins toward 40 nm, vertical confinement collapses: getting any usable
 # n_A/n_B and a significant Δn_g out of a sub-wavelength segmented WGB requires MUCH wider
-# lateral widths (3–10 µm, vs. ~0.1–0.4 µm at 400 nm) and correspondingly wider WGA–WGB and
+# lateral widths (2–7.5 µm, vs. ~0.1–0.4 µm at 400 nm) and correspondingly wider WGA–WGB and
 # rail-to-rail gaps, a wider simulation domain to fit them, and finer grid spacing to resolve the
 # thin core itself. `_si3n4_geometry_defaults`/`_si3n4_grid_baseline` below scale the design-space
-# bounds and grid with thickness accordingly, but — unlike the single-λ_C, single-thickness
-# version of this script — these per-thickness bounds/starting points are heuristic (not
-# individually feasibility-probed the way the original 400-nm point design was): rerun with
+# bounds and grid with thickness accordingly (grids are deliberately modest, not fully resolved,
+# so the 6-thickness × 11-λ_C sweep finishes in a practical amount of time by default) — but,
+# unlike the single-λ_C, single-thickness version of this script, these per-thickness
+# bounds/starting points are heuristic (not individually feasibility-probed the way the original
+# 400-nm point design was): rerun with
 # `--quality=high`/`--quality=ultra` (see example_settings.jl) for production-fidelity results,
 # and inspect each case's `*_report.png` for a genuine crossing with the correct Δn_g sign before
 # trusting a given thickness's summary grid.
@@ -71,26 +73,29 @@ see module header for why thinner cores need much wider structures."
 function si3n4_geometry_defaults(t)
     t >= 0.30 && return (p0=[0.28, 0.14, 0.12], lo=[0.20, 0.10, 0.10], hi=[0.40, 0.18, 0.18])
     t >= 0.15 && return (p0=[0.45, 0.22, 0.18], lo=[0.30, 0.15, 0.12], hi=[0.70, 0.32, 0.30])
-    t >= 0.09 && return (p0=[4.00, 2.00, 1.00], lo=[3.00, 1.20, 0.60], hi=[6.00, 3.20, 2.00])
-    t >= 0.07 && return (p0=[5.00, 2.40, 1.20], lo=[3.50, 1.40, 0.80], hi=[7.00, 3.80, 2.50])
-    t >= 0.05 && return (p0=[6.00, 3.00, 1.50], lo=[4.00, 1.80, 1.00], hi=[8.50, 4.50, 3.00])
-    return (p0=[7.50, 3.60, 2.00], lo=[5.00, 2.20, 1.20], hi=[10.00, 5.50, 3.80])
+    t >= 0.09 && return (p0=[3.00, 1.50, 0.80], lo=[2.20, 0.90, 0.50], hi=[4.50, 2.40, 1.50])
+    t >= 0.07 && return (p0=[3.60, 1.80, 1.00], lo=[2.60, 1.00, 0.60], hi=[5.50, 2.80, 1.80])
+    t >= 0.05 && return (p0=[4.20, 2.10, 1.20], lo=[3.00, 1.20, 0.70], hi=[6.50, 3.40, 2.20])
+    return (p0=[5.00, 2.50, 1.40], lo=[3.50, 1.50, 0.90], hi=[7.50, 4.00, 2.60])
 end
 
 "Baseline (Lx0, Ly0, nx0, ny0) at `cfg.resolution_scale=cfg.domain_scale=1` for one Si₃N₄
-thickness `t` (µm): wider Lx and finer ny for thinner, laterally-wider designs."
+thickness `t` (µm): wider Lx and finer ny for thinner, laterally-wider designs. Kept modest
+(rather than fully resolving these thin, wide structures) so the 6-thickness × 11-λC_C sweep
+finishes in a practical amount of time by default; rerun a given thickness with
+`--quality=high`/`--quality=ultra` for production-fidelity results."
 function si3n4_grid_baseline(t)
     t >= 0.30 && return (Lx0=6.0, Ly0=3.0, nx0=48, ny0=30)
     t >= 0.15 && return (Lx0=8.0, Ly0=3.0, nx0=64, ny0=36)
-    t >= 0.09 && return (Lx0=20.0, Ly0=3.0, nx0=160, ny0=48)
-    t >= 0.07 && return (Lx0=24.0, Ly0=3.0, nx0=180, ny0=56)
-    t >= 0.05 && return (Lx0=28.0, Ly0=3.0, nx0=200, ny0=64)
-    return (Lx0=34.0, Ly0=3.0, nx0=220, ny0=72)
+    t >= 0.09 && return (Lx0=12.0, Ly0=2.6, nx0=84, ny0=34)
+    t >= 0.07 && return (Lx0=14.0, Ly0=2.6, nx0=98, ny0=38)
+    t >= 0.05 && return (Lx0=16.0, Ly0=2.6, nx0=112, ny0=42)
+    return (Lx0=18.0, Ly0=2.6, nx0=126, ny0=46)
 end
 
 "Coupling-gap taper range (g_start, g_end) (µm): wider structures need wider separation gaps to
 reach the weakly-coupled output state."
-si3n4_taper_gaps(t) = t >= 0.15 ? (0.30, 2.00) : (1.00, 6.00)
+si3n4_taper_gaps(t) = t >= 0.15 ? (0.30, 2.00) : (0.80, 4.50)
 
 "Build the DichroicGeometry (buried strip WGA / 3-rail segmented WGB) for one Si₃N₄ thickness
 `t_nm` (nm)."

--- a/examples/designer_dichroic_si3n4.jl
+++ b/examples/designer_dichroic_si3n4.jl
@@ -1,9 +1,11 @@
-# AD-driven DESIGNER — spectrally-selective EME dichroic filter on a NEW stack and NEW target.
+# AD+EME DESIGNER — spectrally-selective dichroic filter, swept over cutoff wavelength and
+# Si₃N₄ core thickness.
 #
 # Applies the mode-crossing / dichroic-filter design methodology of Magden et al., "Transmissive
 # silicon photonic dichroic filters with spectrally selective waveguides," Nat. Commun. 9, 3009
 # (2018) — reproduced on Si SOI in dichroic_filter_magden2018.jl — to a user-controlled
-# **Si₃N₄-on-SiO₂** stack and a NEW cutoff target: **λ_C = 1000 nm**.
+# **Si₃N₄-on-SiO₂** (fully buried/encapsulated) stack, swept over an ARRAY of cutoff targets
+# λ_C = 1.00, 1.05, …, 1.50 µm and over SIX core thicknesses: 40, 60, 80, 100, 200, 400 nm.
 #
 # Dissimilar guides are made exactly as in the paper's Fig. 1b cross-section (not by thickness
 # contrast): a solid strip **WGA** (width w_A) next to a sub-wavelength segmented **WGB** — three
@@ -23,171 +25,101 @@
 # smaller refractive index core, resulting in a smaller group index" (§Coupled-mode description).
 # We therefore reward designs with n_gA − n_gB > 0, matching the paper's sign.
 #
-# ── Stage 1: phase-matching + maximum group-index mismatch (AD, Enzyme) ──────────────────────
-# Design DOF p = (w_A, w_B, g_B). Minimise
-#   L₁(p) = (n_A(λ_C,p) − n_B(λ_C,p))² − β·(n_gA(λ_C,p) − n_gB(λ_C,p))
-# with **OptiMode's automatic differentiation**: each of n_A, n_B, n_gA, n_gB and their p-gradients
-# come from a single Enzyme reverse-mode pass across the geometry→dielectric→eigensolve pipeline
-# (`geom_value_grad`, designer_common.jl). Minimizing L₁ drives the crossing to λ_C while, among
-# the crossing-satisfying designs, preferring the largest group-index mismatch in the paper's
-# sign — i.e. the sharpest, most clearly-defined single-wavelength cutoff.
+# ── Thin-core caveat ──────────────────────────────────────────────────────────────────────────
+# As the Si₃N₄ core thins toward 40 nm, vertical confinement collapses: getting any usable
+# n_A/n_B and a significant Δn_g out of a sub-wavelength segmented WGB requires MUCH wider
+# lateral widths (3–10 µm, vs. ~0.1–0.4 µm at 400 nm) and correspondingly wider WGA–WGB and
+# rail-to-rail gaps, a wider simulation domain to fit them, and finer grid spacing to resolve the
+# thin core itself. `_si3n4_geometry_defaults`/`_si3n4_grid_baseline` below scale the design-space
+# bounds and grid with thickness accordingly, but — unlike the single-λ_C, single-thickness
+# version of this script — these per-thickness bounds/starting points are heuristic (not
+# individually feasibility-probed the way the original 400-nm point design was): rerun with
+# `--quality=high`/`--quality=ultra` (see example_settings.jl) for production-fidelity results,
+# and inspect each case's `*_report.png` for a genuine crossing with the correct Δn_g sign before
+# trusting a given thickness's summary grid.
 #
-# ── Stage 2: adiabatic taper length (EME) ────────────────────────────────────────────────────
-# With the optimized cross-section fixed, build the actual two-waveguide coupled structure and
-# an EME cascade of `cfg.n_cells` cells over which the WGA–WGB edge gap widens from a strongly-
-# coupled interaction value to a well-separated output value (the paper's "section ③"). We
-# search for the *shortest* taper length whose EME-computed quasi-even → quasi-odd mode mixing
-# (`power_coupling`, the exact non-adiabatic loss) stays below a target at both a short-pass and
-# a long-pass test wavelength — i.e. the shortest adiabatic (low-loss) transition, following the
-# paper's own Fig. 3b–d methodology of choosing section lengths from transmission-vs-length
-# curves.
+# ── Two-stage design per (thickness, λ_C) case (dichroic_designer_common.jl) ─────────────────
+# Stage 1 (AD, Enzyme): optimize p=(w_A, w_B, g_B) for phase matching at λ_C with maximum
+# n_gA−n_gB (paper sign), via a two-phase warm start that avoids a soft-penalty equilibrium bias
+# (see dichroic_designer_common.jl header). Stage 2 (EME): shortest WGA–WGB gap-taper length
+# whose quasi-even→quasi-odd mode mixing stays below tolerance at both band edges. Each case also
+# gets a dense broadband transmission spectrum and TE00 |E| field profiles at the cutoff and at
+# ±0.20 µm, and a combined per-case report figure + CSV trace/summary row
+# (`dichroic_designer_common.jl`). Each thickness gets one summary grid of all 11 λ_C spectra on
+# matching wavelength axes with the λ_C target marked.
 #
-# Settings (see examples/README.md): --n-freqs (post-optimization crossing sweep, default 11),
-# --n-cells (EME taper cell count, default 6), --resolution-scale / --domain-scale (grid).
+# Settings (see examples/README.md): --n-freqs (dispersion/spectrum sweep nodes, default 11),
+# --n-dense (dense spectrum resolution, default 400), --resolution-scale/--domain-scale/--n-cells
+# or the bundled --quality=low|medium|high|ultra preset (grid + EME taper cell count).
 #
-# Run:  julia --project=. examples/designer_dichroic_si3n4.jl   (needs CairoMakie)
-#       julia --project=. examples/designer_dichroic_si3n4.jl --resolution-scale=1.5
+# Run:  julia --project=. examples/designer_dichroic_si3n4.jl                    (needs CairoMakie)
+#       julia --project=. examples/designer_dichroic_si3n4.jl --quality=high
+#       OPTIMODE_QUALITY=high julia --project=. examples/designer_dichroic_si3n4.jl
 
-include(joinpath(@__DIR__, "designer_common.jl"))
-include(joinpath(@__DIR__, "eme_reproductions_common.jl"))
+include(joinpath(@__DIR__, "dichroic_designer_common.jl"))
 using CairoMakie
 
-cfg = example_settings(n_freqs=11, n_cells=6)
+cfg = example_settings(n_freqs=11, n_dense=400)
 solver = KrylovKitEigsolve()
-λC_target = 1.00                              # NEW cutoff target (µm)
-t = 0.40                                       # uniform Si₃N₄ thickness for WGA & WGB (µm)
-mats = [Si₃N₄, SiO₂]
-mv = matvals_builder(mats; air=false)         # Si₃N₄ cores buried in SiO₂
-grid = mk_grid(cfg, 6.0, 3.0, 48, 30)
-om_C = 1 / λC_target
+mats = (Si₃N₄, SiO₂)
+mv = matvals_builder(collect(mats); air=false)   # built at top level — see DichroicGeometry docstring
+λC_grid = collect(1.00:0.05:1.50)             # 11 targets, 1000–1500 nm
+thicknesses_nm = (40, 60, 80, 100, 200, 400)   # Si₃N₄ core full thickness
 
-# --- geometry: solid WGA vs. 3-segment (rail) WGB, both isolated for stage 1 ------------------
-rail(cx, w) = MaterialShape(Cuboid([cx, 0.0], [w, t], [1.0 0.0; 0.0 1.0]), 1)
-wgA_shapes(p) = (rail(0.0, p[1]),)                                    # solid WGA, width p[1]
-wgB_shapes(p) = (w = p[2]; g = p[3]; (rail(-(w + g), w), rail(0.0, w), rail(w + g, w)))  # 3-rail WGB
-mindsA = (1, 2); mindsB = (1, 1, 1, 2)
-
-nA_of(p, λ) = neff_of(diel_p(wgA_shapes, mv, mindsA, grid, p, 1/λ)[1], 1/λ, grid, solver)
-nB_of(p, λ) = neff_of(diel_p(wgB_shapes, mv, mindsB, grid, p, 1/λ)[1], 1/λ, grid, solver)
-
-# --- Stage 1: AD-optimize p=(w_A, w_B, g_B) for crossing at λ_C + max n_gA−n_gB ---------------
-# A single soft-penalty loss r² − β·Δn_g has a structural equilibrium bias: near the crossing
-# (r→0) the r² gradient vanishes while the constant −β·∇Δn_g term does not, so a fixed-β run
-# settles at some small but nonzero r rather than the crossing itself. We instead warm-start in
-# two phases — (1a) minimize the crossing condition alone (β=0) to lock onto λ_C precisely, then
-# (1b) a short, small-step refinement of the *combined* loss from that crossing, which nudges
-# Δn_g in the paper's sign without re-opening the gap. Both phases share the same AD machinery.
-const β_gvm = 0.002
-lo1, hi1 = [0.20, 0.10, 0.10], [0.40, 0.18, 0.18]
-"Loss and Enzyme gradient of the pure crossing condition L(p) = (n_A−n_B)² at λ_C."
-function loss_grad_crossing(p)
-    nA, gnA = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgA_shapes, mv, mindsA, grid, p, om_C)
-    nB, gnB = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgB_shapes, mv, mindsB, grid, p, om_C)
-    r = nA - nB
-    (r^2, 2r .* (gnA .- gnB))
-end
-"Loss and Enzyme gradient of L₁(p) = (n_A−n_B)² − β·(n_gA−n_gB) at λ_C."
-function loss_grad_stage1(p)
-    nA, gnA   = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgA_shapes, mv, mindsA, grid, p, om_C)
-    nB, gnB   = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), wgB_shapes, mv, mindsB, grid, p, om_C)
-    ngA, gngA = geom_value_grad((ei, de) -> ng_of(ei, de, om_C, grid, solver), wgA_shapes, mv, mindsA, grid, p, om_C)
-    ngB, gngB = geom_value_grad((ei, de) -> ng_of(ei, de, om_C, grid, solver), wgB_shapes, mv, mindsB, grid, p, om_C)
-    r = nA - nB
-    L = r^2 - β_gvm * (ngA - ngB)
-    g = 2r .* (gnA .- gnB) .- β_gvm .* (gngA .- gngB)
-    (L, g)
+"Heuristic (w_A, w_B, g_B) starting point + box bounds (µm) for one Si₃N₄ thickness `t` (µm);
+see module header for why thinner cores need much wider structures."
+function si3n4_geometry_defaults(t)
+    t >= 0.30 && return (p0=[0.28, 0.14, 0.12], lo=[0.20, 0.10, 0.10], hi=[0.40, 0.18, 0.18])
+    t >= 0.15 && return (p0=[0.45, 0.22, 0.18], lo=[0.30, 0.15, 0.12], hi=[0.70, 0.32, 0.30])
+    t >= 0.09 && return (p0=[4.00, 2.00, 1.00], lo=[3.00, 1.20, 0.60], hi=[6.00, 3.20, 2.00])
+    t >= 0.07 && return (p0=[5.00, 2.40, 1.20], lo=[3.50, 1.40, 0.80], hi=[7.00, 3.80, 2.50])
+    t >= 0.05 && return (p0=[6.00, 3.00, 1.50], lo=[4.00, 1.80, 1.00], hi=[8.50, 4.50, 3.00])
+    return (p0=[7.50, 3.60, 2.00], lo=[5.00, 2.20, 1.20], hi=[10.00, 5.50, 3.80])
 end
 
-p0 = [0.28, 0.14, 0.12]                      # start: w_A, w_B(seg), g_B(rail gap) [µm]
-@printf("== dichroic designer: Si₃N₄ solid-WGA / segmented-WGB, cutoff target λ_C=%.0f nm ==\n", 1e3λC_target)
-@printf("start (w_A,w_B,g_B)=(%.3f,%.3f,%.3f) µm: n_A=%.4f n_B=%.4f\n",
-        p0..., nA_of(p0, λC_target), nB_of(p0, λC_target))
-println("-- phase 1a: lock the crossing (β=0) --")
-res0 = optimize_design(loss_grad_crossing, p0; lo=lo1, hi=hi1, iters=40, lr=0.01)
-println("-- phase 1b: refine for max Δn_g near the crossing (small steps) --")
-res1 = optimize_design(loss_grad_stage1, res0.p; lo=lo1, hi=hi1, iters=12, lr=0.002)
-p★ = res1.p
-w_A★, w_B★, g_B★ = p★
-nA★, ngA★ = nA_of(p★, λC_target), ng_of(diel_p(wgA_shapes, mv, mindsA, grid, p★, om_C)[1:2]..., om_C, grid, solver)
-nB★, ngB★ = nB_of(p★, λC_target), ng_of(diel_p(wgB_shapes, mv, mindsB, grid, p★, om_C)[1:2]..., om_C, grid, solver)
-@printf("optimized (w_A,w_B,g_B)=(%.3f,%.3f,%.3f) µm: n_A=%.4f n_B=%.4f  n_gA-n_gB=%+.3f (paper sign: >0)\n",
-        p★..., nA★, nB★, ngA★ - ngB★)
-
-# --- dispersion crossing before / after --------------------------------------------------------
-λs = collect(range(0.80, 1.30; length=cfg.n_freqs))
-nA0, nB0 = [nA_of(p0, λ) for λ in λs], [nB_of(p0, λ) for λ in λs]
-nA1, nB1 = [nA_of(p★, λ) for λ in λs], [nB_of(p★, λ) for λ in λs]
-λC0, λC★ = crossing_wavelength(λs, nA0, nB0), crossing_wavelength(λs, nA1, nB1)
-@printf("cutoff: start λ_C=%s µm → optimized λ_C=%s µm (target %.3f)\n",
-        isnan(λC0) ? "—" : string(round(λC0, digits=3)), isnan(λC★) ? "—" : string(round(λC★, digits=3)), λC_target)
-
-# --- Stage 2: EME adiabatic taper — shortest length keeping mode-mixing loss low --------------
-println("== Stage 2: EME adiabatic taper length search (WGA–WGB coupling gap) ==")
-g_start, g_end = 0.30, 2.00                    # coupled (interaction) → separated (output) gap [µm]
-
-"Coupled 4-shape (WGA + 3-segment WGB) cross-section at WGA–WGB edge-to-edge gap `gap`."
-function coupled_shapes(gap)
-    xA = -(gap / 2 + w_A★ / 2)
-    xB = gap / 2 + w_B★ / 2
-    (rail(xA, w_A★), rail(xB, w_B★), rail(xB + w_B★ + g_B★, w_B★), rail(xB + 2 * (w_B★ + g_B★), w_B★))
-end
-minds_AB = (1, 1, 1, 1, 2)
-
-"Non-adiabatic loss (quasi-even → quasi-odd mode mixing) of a K-cell, length-`L` gap taper at ω."
-function adiabatic_loss(L, ω; K=cfg.n_cells)
-    edges = collect(range(0.0, L; length=K + 1))
-    gaps = collect(range(g_start, g_end; length=K))
-    cells = [Cell(i, (edges[i]+edges[i+1])/2, edges[i+1]-edges[i],
-                  CrossSection(collect(MaterialShape, coupled_shapes(gaps[i])), collect(Int, minds_AB)))
-             for i in 1:K]
-    res = eme(cells, mats, ω, grid, solver; nev=2, k_tol=1e-7)
-    power_coupling(res; in_mode=1, out_mode=2)
+"Baseline (Lx0, Ly0, nx0, ny0) at `cfg.resolution_scale=cfg.domain_scale=1` for one Si₃N₄
+thickness `t` (µm): wider Lx and finer ny for thinner, laterally-wider designs."
+function si3n4_grid_baseline(t)
+    t >= 0.30 && return (Lx0=6.0, Ly0=3.0, nx0=48, ny0=30)
+    t >= 0.15 && return (Lx0=8.0, Ly0=3.0, nx0=64, ny0=36)
+    t >= 0.09 && return (Lx0=20.0, Ly0=3.0, nx0=160, ny0=48)
+    t >= 0.07 && return (Lx0=24.0, Ly0=3.0, nx0=180, ny0=56)
+    t >= 0.05 && return (Lx0=28.0, Ly0=3.0, nx0=200, ny0=64)
+    return (Lx0=34.0, Ly0=3.0, nx0=220, ny0=72)
 end
 
-λ_short, λ_long = λC_target - 0.15, λC_target + 0.15
-# Loss decreases with L as expected for an adiabatic transition, but is not perfectly monotonic
-# at very long L (nev=2 mode tracking becomes less reliable over many cells); `findfirst` below
-# only needs the *first* L meeting tolerance, so this doesn't affect the reported L★.
-Ls = [5.0, 10.0, 20.0, 40.0, 80.0, 160.0, 320.0, 640.0]
-losses = Float64[]
-for L in Ls
-    ℓ = max(adiabatic_loss(L, 1/λ_short), adiabatic_loss(L, 1/λ_long))
-    push!(losses, ℓ)
-    @printf("  L=%6.1f µm  max(mode-mixing loss)=%.4e\n", L, ℓ)
-    flush(stdout)
+"Coupling-gap taper range (g_start, g_end) (µm): wider structures need wider separation gaps to
+reach the weakly-coupled output state."
+si3n4_taper_gaps(t) = t >= 0.15 ? (0.30, 2.00) : (1.00, 6.00)
+
+"Build the DichroicGeometry (buried strip WGA / 3-rail segmented WGB) for one Si₃N₄ thickness
+`t_nm` (nm)."
+function si3n4_geometry(t_nm, cfg, mv)
+    t = 1e-3 * t_nm
+    rail(cx, w) = MaterialShape(Cuboid([cx, 0.0], [w, t], [1.0 0.0; 0.0 1.0]), 1)
+    wgA_shapes(p) = (rail(0.0, p[1]),)
+    wgB_shapes(p) = (w = p[2]; g = p[3]; (rail(-(w + g), w), rail(0.0, w), rail(w + g, w)))
+    function coupled_shapes(p, gap)
+        w_A, w_B, g_B = p
+        xA, xB = -(gap/2 + w_A/2), gap/2 + w_B/2
+        (rail(xA, w_A), rail(xB, w_B), rail(xB + w_B + g_B, w_B), rail(xB + 2*(w_B + g_B), w_B))
+    end
+    d = si3n4_geometry_defaults(t)
+    gb = si3n4_grid_baseline(t)
+    g_start, g_end = si3n4_taper_gaps(t)
+    grid = mk_grid(cfg, gb.Lx0, gb.Ly0, gb.nx0, gb.ny0)
+    DichroicGeometry(; tag=@sprintf("Si3N4_t%03dnm", t_nm), mats, mv, wgA_shapes, wgB_shapes, coupled_shapes,
+        mindsA=(1, 2), mindsB=(1, 1, 1, 2), mindsAB=(1, 1, 1, 1, 2), grid,
+        p0=d.p0, lo=d.lo, hi=d.hi, g_start=g_start, g_end=g_end)
 end
-adiabatic_tol = 0.01
-i_ok = findfirst(≤(adiabatic_tol), losses)
-L★ = i_ok === nothing ? Ls[end] : Ls[i_ok]
-@printf("shortest adiabatic taper (loss ≤ %.0e): L★ = %.1f µm%s\n",
-        adiabatic_tol, L★, i_ok === nothing ? "  (tolerance not reached within Ls — using longest tested)" : "")
 
-# --- plots ------------------------------------------------------------------------------------
-fig1 = Figure(size=(920, 340))
-ax1 = Axis(fig1[1, 1], xlabel="Adam iteration", ylabel="loss  (log scale)", yscale=log10,
-    title=@sprintf("Stage 1: AD-optimized crossing + max Δn_g (Si₃N₄, %.0f nm)", 1e3λC_target))
-lines!(ax1, 1:length(res0.history), max.(res0.history, 1e-12), color=:dodgerblue, linewidth=2, label="1a: (n_A−n_B)²")
-lines!(ax1, length(res0.history) .+ (1:length(res1.history)), max.(abs.(res1.history), 1e-12),
-    color=:crimson, linewidth=2, label="1b: |(n_A−n_B)² − β·Δn_g|  (loss is negative ⇒ Δn_g improving)")
-vlines!(ax1, [length(res0.history) + 0.5], color=:gray, linestyle=:dot)
-axislegend(ax1, position=:rt, labelsize=9)
-ax2 = Axis(fig1[1, 2], xlabel="wavelength (µm)", ylabel="effective index",
-    title="WGA/WGB mode crossing: start vs optimized")
-lines!(ax2, λs, nB0, color=:black, linewidth=2, linestyle=:dash, label="WGB start")
-lines!(ax2, λs, nA0, color=:dodgerblue, linewidth=2, linestyle=:dash, label="WGA start")
-lines!(ax2, λs, nB1, color=:gray30, linewidth=2, label="WGB optimized")
-lines!(ax2, λs, nA1, color=:crimson, linewidth=2, label="WGA optimized")
-vlines!(ax2, [λC_target], color=:gray, linestyle=:dot)
-axislegend(ax2, position=:rt, labelsize=10)
-save(joinpath(OUTDIR, "designer_dichroic_si3n4_stage1.png"), fig1)
-
-fig2 = Figure(size=(560, 380))
-ax3 = Axis(fig2[1, 1], xlabel="taper length L (µm)", ylabel="quasi-even → quasi-odd mode mixing",
-    title="Stage 2: adiabatic taper length search (EME)", xscale=log10, yscale=log10)
-scatterlines!(ax3, Ls, max.(losses, 1e-12), color=:seagreen, linewidth=2, marker=:circle)
-hlines!(ax3, [adiabatic_tol], color=:gray, linestyle=:dash, label=@sprintf("tolerance %.0e", adiabatic_tol))
-vlines!(ax3, [L★], color=:crimson, linestyle=:dot, label=@sprintf("L★=%.0f µm", L★))
-axislegend(ax3, position=:rt)
-save(joinpath(OUTDIR, "designer_dichroic_si3n4_stage2.png"), fig2)
-
-println("saved: designer_dichroic_si3n4_stage1.png, designer_dichroic_si3n4_stage2.png → ", OUTDIR)
+println("== Si₃N₄ dichroic designer: λ_C ∈ [", λC_grid[1], ", ", λC_grid[end],
+        "] µm × t ∈ ", thicknesses_nm, " nm ==")
+all_results = Dict{Int,Any}()
+for t_nm in thicknesses_nm
+    @printf("\n---- Si₃N₄ t=%d nm ----\n", t_nm)
+    geo = si3n4_geometry(t_nm, cfg, mv)
+    all_results[t_nm] = run_dichroic_sweep(geo, λC_grid, cfg, solver; xlims=(0.6, 1.9))
+end
+println("\ndone: ", length(thicknesses_nm), " thicknesses × ", length(λC_grid), " cutoff targets → ",
+        length(thicknesses_nm) * length(λC_grid), " cases. Summary grids + CSVs → ", OUTDIR)

--- a/examples/dichroic_designer_common.jl
+++ b/examples/dichroic_designer_common.jl
@@ -1,0 +1,276 @@
+# Shared, geometry-agnostic machinery for the dichroic-filter *designer* scripts
+# (`designer_dichroic_si3n4.jl`, `designer_dichroic_linbo3_litao3.jl`): given a
+# `DichroicGeometry` (a material stack + WGA/WGB/coupled shape builders for one physical
+# waveguide family — buried strip, or rib-on-slab), sweep the two-stage AD+EME design of
+# `designer_dichroic_si3n4.jl` over an array of target cutoff wavelengths λ_C, saving a
+# per-case report figure + CSV row, then a per-configuration summary grid.
+#
+# Stage 1 (AD, Enzyme) and Stage 2 (EME taper-length search) are exactly the two-phase
+# warm-start / adiabatic-taper-search methods validated for the Si₃N₄ solid/segmented design in
+# the single-target version of this file; see that script's header for the physics and the
+# soft-penalty-equilibrium-bias fix they encode. This file only factors those two stages, plus a
+# dense transmission spectrum and TE00 field-profile helper, so they can be reused across the
+# λ_C sweep and across material/geometry families without duplicating the optimization logic.
+
+include(joinpath(@__DIR__, "designer_common.jl"))
+include(joinpath(@__DIR__, "eme_reproductions_common.jl"))
+
+"""
+    DichroicGeometry
+
+One physical waveguide family (a material stack + shape builders) for the dichroic designer.
+`wgA_shapes`/`wgB_shapes` take the AD design vector `p = [w_A, w_B, g_B]` (µm) and return the
+isolated-guide `MaterialShape` tuple; `coupled_shapes(p, gap)` returns the WGA+WGB cross-section
+with edge-to-edge coupling gap `gap`, WGA centred at negative x and WGB at positive x so the
+WGA|WGB divider is always x=0 (`x_split=0.0` is used uniformly below).
+
+`mv` must be built at TOP-LEVEL script scope via `matvals_builder(collect(mats); air=false)`
+before constructing this struct (i.e. passed in already-built, not built inside a function here):
+`_f_ε_mats`/`matvals_builder` generate their returned closure via runtime `eval`, so calling it
+from inside a nested function hits a Julia world-age error the first time the closure is used
+later in that same call (`MethodError: ... method too new to be called from this world context`)
+— building it at top level and threading it through as a field sidesteps that entirely.
+"""
+Base.@kwdef struct DichroicGeometry
+    tag::String
+    mats::Tuple
+    mv::Function
+    wgA_shapes::Function
+    wgB_shapes::Function
+    coupled_shapes::Function
+    mindsA::Tuple
+    mindsB::Tuple
+    mindsAB::Tuple
+    grid::Any
+    p0::Vector{Float64}
+    lo::Vector{Float64}
+    hi::Vector{Float64}
+    g_start::Float64 = 0.30
+    g_end::Float64 = 2.00
+end
+
+# ---------------------------------------------------------------------------------------
+# Stage 1: two-phase AD crossing + max-Δn_g optimization (Enzyme)
+# ---------------------------------------------------------------------------------------
+
+"""
+    optimize_dichroic_crossing(geo, λC_target, solver; β_gvm, iters1a, iters1b, lr1a, lr1b)
+
+Two-phase warm-start AD optimization of `p=(w_A,w_B,g_B)`: phase 1a locks the crossing
+`(n_A-n_B)²→0` at `λC_target` (β=0); phase 1b then does a short, small-step refinement of the
+combined loss `(n_A-n_B)² - β·(n_gA-n_gB)` from that crossing, nudging the group-index mismatch
+in the paper's sign (n_gA>n_gB) without reopening the gap (see module header)."""
+function optimize_dichroic_crossing(geo::DichroicGeometry, λC_target, solver;
+        β_gvm=0.002, iters1a=40, iters1b=12, lr1a=0.01, lr1b=0.002)
+    om_C = 1 / λC_target
+    mv = geo.mv
+    grid = geo.grid
+    nA_of(p, λ) = neff_of(diel_p(geo.wgA_shapes, mv, geo.mindsA, grid, p, 1/λ)[1], 1/λ, grid, solver)
+    nB_of(p, λ) = neff_of(diel_p(geo.wgB_shapes, mv, geo.mindsB, grid, p, 1/λ)[1], 1/λ, grid, solver)
+
+    function loss_grad_crossing(p)
+        nA, gnA = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), geo.wgA_shapes, mv, geo.mindsA, grid, p, om_C)
+        nB, gnB = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), geo.wgB_shapes, mv, geo.mindsB, grid, p, om_C)
+        r = nA - nB
+        (r^2, 2r .* (gnA .- gnB))
+    end
+    function loss_grad_stage1(p)
+        nA, gnA   = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), geo.wgA_shapes, mv, geo.mindsA, grid, p, om_C)
+        nB, gnB   = geom_value_grad((ei, de) -> neff_of(ei, om_C, grid, solver), geo.wgB_shapes, mv, geo.mindsB, grid, p, om_C)
+        ngA, gngA = geom_value_grad((ei, de) -> ng_of(ei, de, om_C, grid, solver), geo.wgA_shapes, mv, geo.mindsA, grid, p, om_C)
+        ngB, gngB = geom_value_grad((ei, de) -> ng_of(ei, de, om_C, grid, solver), geo.wgB_shapes, mv, geo.mindsB, grid, p, om_C)
+        r = nA - nB
+        L = r^2 - β_gvm * (ngA - ngB)
+        g = 2r .* (gnA .- gnB) .- β_gvm .* (gngA .- gngB)
+        (L, g)
+    end
+
+    res0 = optimize_design(loss_grad_crossing, geo.p0; lo=geo.lo, hi=geo.hi, iters=iters1a, lr=lr1a, verbose=false)
+    res1 = optimize_design(loss_grad_stage1, res0.p; lo=geo.lo, hi=geo.hi, iters=iters1b, lr=lr1b, verbose=false)
+    p★ = res1.p
+    nA★, nB★ = nA_of(p★, λC_target), nB_of(p★, λC_target)
+    ngA★ = ng_of(diel_p(geo.wgA_shapes, mv, geo.mindsA, grid, p★, om_C)[1:2]..., om_C, grid, solver)
+    ngB★ = ng_of(diel_p(geo.wgB_shapes, mv, geo.mindsB, grid, p★, om_C)[1:2]..., om_C, grid, solver)
+    (; p=p★, mv, nA_of, nB_of, nA=nA★, nB=nB★, ngA=ngA★, ngB=ngB★, res0, res1)
+end
+
+# ---------------------------------------------------------------------------------------
+# Stage 2: EME adiabatic taper length search
+# ---------------------------------------------------------------------------------------
+
+"Shortest K-cell WGA–WGB gap-taper length (of `Ls`) whose EME quasi-even→quasi-odd mode mixing
+stays ≤ `tol` at both `λC_target∓0.15` µm."
+function adiabatic_taper_length(geo::DichroicGeometry, p★, mats_vec, λC_target, n_cells, solver;
+        tol=0.01, Ls=(5.0, 10.0, 20.0, 40.0, 80.0, 160.0, 320.0, 640.0))
+    grid = geo.grid
+    λ_short, λ_long = λC_target - 0.15, λC_target + 0.15
+    function adiabatic_loss(L, ω)
+        edges = collect(range(0.0, L; length=n_cells + 1))
+        gaps = collect(range(geo.g_start, geo.g_end; length=n_cells))
+        cells = [Cell(i, (edges[i]+edges[i+1])/2, edges[i+1]-edges[i],
+                      CrossSection(collect(MaterialShape, geo.coupled_shapes(p★, gaps[i])), collect(Int, geo.mindsAB)))
+                 for i in 1:n_cells]
+        res = eme(cells, mats_vec, ω, grid, solver; nev=2, k_tol=1e-7)
+        power_coupling(res; in_mode=1, out_mode=2)
+    end
+    losses = Float64[]
+    for L in Ls
+        push!(losses, max(adiabatic_loss(L, 1/λ_short), adiabatic_loss(L, 1/λ_long)))
+    end
+    i_ok = findfirst(≤(tol), losses)
+    L★ = i_ok === nothing ? Ls[end] : Ls[i_ok]
+    (; Ls=collect(Ls), losses, L★, tol, ok=(i_ok !== nothing))
+end
+
+# ---------------------------------------------------------------------------------------
+# Dense transmission spectrum + TE00 field profiles (quasi-even supermode of the *interaction*
+# cross-section, i.e. coupled_shapes at gap=g_start — the ideal-adiabatic estimate of the finished
+# device's response, following dichroic_filter_magden2018.jl's convention).
+# ---------------------------------------------------------------------------------------
+
+"Dense short-/long-pass transmission spectrum around `λ_center`, from `n_freqs` real supermode
+solves of the coupled (interaction-gap) cross-section interpolated onto `n_dense` points."
+function dichroic_dense_spectrum(geo::DichroicGeometry, p★, mv, solver, λ_center; n_freqs=11, n_dense=400, halfspan=0.35)
+    λs = collect(range(λ_center - halfspan, λ_center + halfspan; length=n_freqs))
+    fracA = zero(λs)
+    minds = collect(Int, geo.mindsAB)
+    for (j, λ) in enumerate(λs)
+        sup = supermodes(geo.coupled_shapes(p★, geo.g_start), minds, mv, 1/λ, geo.grid, solver; nev=4)
+        fracA[j] = port_fraction(sup[1].E, geo.grid, 0.0)
+    end
+    λdense = collect(range(λs[1], λs[end]; length=n_dense))
+    T_short, T_long = dichroic_spectrum(λs, fracA, λdense)
+    (; λs, fracA, λdense, T_short, T_long)
+end
+
+"TE00 (quasi-even supermode) |E| field of the coupled interaction cross-section at wavelength `λ`."
+function dichroic_field(geo::DichroicGeometry, p★, mv, solver, λ)
+    supermodes(geo.coupled_shapes(p★, geo.g_start), collect(Int, geo.mindsAB), mv, 1/λ, geo.grid, solver; nev=4)[1].E
+end
+
+# ---------------------------------------------------------------------------------------
+# One (geometry, λC_target) case: run both stages, dense spectrum, 3 field profiles; save a
+# combined per-case report figure + append a row to the configuration's summary CSV.
+# ---------------------------------------------------------------------------------------
+
+"""
+    run_dichroic_case(geo, λC_target, cfg, solver) -> NamedTuple
+
+Runs Stage 1 (AD crossing + max Δn_g), Stage 2 (EME adiabatic taper length), a dense broadband
+transmission spectrum, and TE00 field profiles at the red-detuned/cutoff/blue-detuned test
+wavelengths for one `(geo, λC_target)` case. Saves one combined report figure
+`<geo.tag>_λC<λC*1000>nm_report.png` to `OUTDIR`."""
+function run_dichroic_case(geo::DichroicGeometry, λC_target, cfg, solver; β_gvm=0.002, taper_tol=0.01)
+    mats_vec = collect(geo.mats)
+    stage1 = optimize_dichroic_crossing(geo, λC_target, solver; β_gvm=β_gvm)
+    stage2 = adiabatic_taper_length(geo, stage1.p, mats_vec, λC_target, cfg.n_cells, solver; tol=taper_tol)
+    spec = dichroic_dense_spectrum(geo, stage1.p, stage1.mv, solver, λC_target; n_freqs=cfg.n_freqs, n_dense=cfg.n_dense)
+
+    λs_disp = collect(range(λC_target - 0.35, λC_target + 0.35; length=cfg.n_freqs))
+    nA0 = [stage1.nA_of(geo.p0, λ) for λ in λs_disp]; nB0 = [stage1.nB_of(geo.p0, λ) for λ in λs_disp]
+    nA1 = [stage1.nA_of(stage1.p, λ) for λ in λs_disp]; nB1 = [stage1.nB_of(stage1.p, λ) for λ in λs_disp]
+    λC_achieved = crossing_wavelength(λs_disp, nA1, nB1)
+
+    λ_show = (λC_target - 0.20, λC_target, λC_target + 0.20)   # red / at-cutoff / blue TE00 fields
+    Efields = [dichroic_field(geo, stage1.p, stage1.mv, solver, λ) for λ in λ_show]
+
+    tag_λ = @sprintf("%s_λC%04dnm", geo.tag, round(Int, 1000λC_target))
+    @printf("[%s] target λC=%.3f µm → p=(%.3f,%.3f,%.3f) µm  n_A=%.4f n_B=%.4f  n_gA-n_gB=%+.3f  λC_achieved=%s  L★=%.0f µm%s\n",
+            tag_λ, λC_target, stage1.p..., stage1.nA, stage1.nB, stage1.ngA - stage1.ngB,
+            isnan(λC_achieved) ? "none" : string(round(λC_achieved; digits=3)), stage2.L★, stage2.ok ? "" : " (tol not reached)")
+    flush(stdout)
+
+    # --- per-case combined report figure -------------------------------------------------------
+    xc, yc = grid_coords(geo.grid)
+    fig = Figure(size=(1500, 760))
+    ax1 = Axis(fig[1, 1], xlabel="Adam iteration", ylabel="loss (log)", yscale=log10, title="Stage 1: AD optimization")
+    lines!(ax1, 1:length(stage1.res0.history), max.(stage1.res0.history, 1e-12), color=:dodgerblue, linewidth=2, label="1a: (n_A−n_B)²")
+    lines!(ax1, length(stage1.res0.history) .+ (1:length(stage1.res1.history)), max.(abs.(stage1.res1.history), 1e-12),
+        color=:crimson, linewidth=2, label="1b: combined")
+    axislegend(ax1, position=:rt, labelsize=8)
+
+    ax2 = Axis(fig[1, 2], xlabel="wavelength (µm)", ylabel="n_eff", title="isolated WGA/WGB crossing")
+    lines!(ax2, λs_disp, nB0, color=:black, linewidth=1.5, linestyle=:dash, label="WGB start")
+    lines!(ax2, λs_disp, nA0, color=:dodgerblue, linewidth=1.5, linestyle=:dash, label="WGA start")
+    lines!(ax2, λs_disp, nB1, color=:gray30, linewidth=2, label="WGB opt")
+    lines!(ax2, λs_disp, nA1, color=:crimson, linewidth=2, label="WGA opt")
+    vlines!(ax2, [λC_target], color=:gray, linestyle=:dot)
+    axislegend(ax2, position=:rt, labelsize=8)
+
+    ax3 = Axis(fig[1, 3], xlabel="taper length L (µm)", ylabel="mode mixing", xscale=log10, yscale=log10,
+        title="Stage 2: taper length search")
+    scatterlines!(ax3, stage2.Ls, max.(stage2.losses, 1e-12), color=:seagreen, linewidth=2, marker=:circle)
+    hlines!(ax3, [stage2.tol], color=:gray, linestyle=:dash)
+    vlines!(ax3, [stage2.L★], color=:crimson, linestyle=:dot)
+
+    ax4 = Axis(fig[1, 4], xlabel="wavelength (µm)", ylabel="transmission",
+        title=@sprintf("dense spectrum (λC target=%.0f nm)", 1000λC_target))
+    lines!(ax4, spec.λdense, spec.T_short, color=:dodgerblue, linewidth=2, label="short-pass (WGA)")
+    lines!(ax4, spec.λdense, spec.T_long, color=:crimson, linewidth=2, label="long-pass (WGB)")
+    vlines!(ax4, [λC_target], color=:gray, linestyle=:dash)
+    axislegend(ax4, position=:rc, labelsize=8)
+
+    for (col, (E, λ)) in enumerate(zip(Efields, λ_show))
+        lbl = col == 1 ? "red (λ_C−0.2µm)" : col == 2 ? "at λ_C" : "blue (λ_C+0.2µm)"
+        ax = Axis(fig[2, col], xlabel="x (µm)", ylabel="y (µm)", aspect=DataAspect(),
+            title=@sprintf("TE00 |E|: %s (%.0f nm)", lbl, 1000λ))
+        heatmap!(ax, xc, yc, absE_norm(E), colormap=:turbo)
+    end
+    Label(fig[2, 4], @sprintf("%s\nλC_target=%.0f nm", geo.tag, 1000λC_target); tellwidth=false, tellheight=false)
+    save(joinpath(OUTDIR, tag_λ * "_report.png"), fig)
+
+    # --- optimization trace data ----------------------------------------------------------------
+    open(joinpath(OUTDIR, tag_λ * "_trace.csv"), "w") do io
+        println(io, "phase,iter,loss")
+        for (i, ℓ) in enumerate(stage1.res0.history); println(io, "1a,", i, ",", ℓ); end
+        for (i, ℓ) in enumerate(stage1.res1.history); println(io, "1b,", i, ",", ℓ); end
+    end
+
+    (; geo, λC_target, λC_achieved, p=stage1.p, nA=stage1.nA, nB=stage1.nB,
+       ngA=stage1.ngA, ngB=stage1.ngB, L★=stage2.L★, taper_ok=stage2.ok, spec, Efields, λ_show,
+       λs_disp, nA0, nB0, nA1, nB1)
+end
+
+# ---------------------------------------------------------------------------------------
+# Full λC sweep for one geometry: run every case, write a summary CSV, and produce a summary
+# grid of subplots (dense transmission spectra, matching x-axes, λC_target as a vertical dashed
+# line) across all swept designs.
+# ---------------------------------------------------------------------------------------
+
+"""
+    run_dichroic_sweep(geo, λC_grid, cfg, solver; xlims=(0.5, 2.0)) -> Vector of case results
+
+Runs [`run_dichroic_case`](@ref) for every `λC_target` in `λC_grid`, writes
+`<geo.tag>_sweep_summary.csv`, and saves `<geo.tag>_summary_grid.png` — a grid of subplots (one
+per λC_target) of the dense transmission spectrum, all sharing the x-axis range `xlims` so the
+cutoffs are directly comparable, each with its target λC_target marked by a vertical dashed
+line."""
+function run_dichroic_sweep(geo::DichroicGeometry, λC_grid, cfg, solver; xlims=(0.5, 2.0), β_gvm=0.002, taper_tol=0.01)
+    cases = [run_dichroic_case(geo, λC, cfg, solver; β_gvm=β_gvm, taper_tol=taper_tol) for λC in λC_grid]
+
+    open(joinpath(OUTDIR, geo.tag * "_sweep_summary.csv"), "w") do io
+        println(io, "λC_target_um,λC_achieved_um,w_A_um,w_B_um,g_B_um,n_A,n_B,ngA_minus_ngB,L_star_um,taper_ok")
+        for c in cases
+            println(io, join((c.λC_target, c.λC_achieved, c.p..., c.nA, c.nB, c.ngA - c.ngB, c.L★, c.taper_ok), ","))
+        end
+    end
+
+    ncols = min(4, length(cases))
+    nrows = cld(length(cases), ncols)
+    fig = Figure(size=(320ncols, 220nrows + 40))
+    Label(fig[0, 1:ncols], geo.tag * " — dichroic filter λC sweep (dense transmission spectra)"; fontsize=16, tellwidth=false)
+    for (i, c) in enumerate(cases)
+        row, col = fld(i - 1, ncols) + 1, mod(i - 1, ncols) + 1
+        ax = Axis(fig[row, col], xlabel="wavelength (µm)", ylabel="transmission",
+            title=@sprintf("λC=%.0f nm", 1000c.λC_target))
+        xlims!(ax, xlims...)
+        ylims!(ax, -0.02, 1.02)
+        lines!(ax, c.spec.λdense, c.spec.T_short, color=:dodgerblue, linewidth=1.5)
+        lines!(ax, c.spec.λdense, c.spec.T_long, color=:crimson, linewidth=1.5)
+        vlines!(ax, [c.λC_target], color=:gray, linestyle=:dash)
+    end
+    save(joinpath(OUTDIR, geo.tag * "_summary_grid.png"), fig)
+    println("saved: ", geo.tag, "_summary_grid.png, ", geo.tag, "_sweep_summary.csv, and ",
+            length(cases), " per-case *_report.png/*_trace.csv → ", OUTDIR)
+    cases
+end

--- a/examples/example_settings.jl
+++ b/examples/example_settings.jl
@@ -33,6 +33,14 @@ Resolved a-la-carte simulation settings for one example run.
 - `n_eme_freqs` — number of wavelengths for a genuinely EME-solved (`eme`/`power_coupling`) dense
   transmission overlay, where the example provides one (see `tfln_combiner_kwolek2026.jl`).
 - `n_cells` — number of cells in an EME cascade (`eme_transmission`/`Cell` count).
+- `quality` — `:low`/`:medium`/`:high`/`:ultra` bundled preset for `resolution_scale`,
+  `domain_scale`, and `n_cells` (see `_QUALITY_PRESETS` below). `:medium` reproduces the
+  pre-existing `1.0`/`1.0`/`6` defaults. This is a convenience layer under the a-la-carte knobs:
+  precedence for each of those three fields is (highest wins) CLI flag > env var > script kwarg >
+  `quality` preset > built-in hardcoded default — so a script that passes its own tuned
+  `resolution_scale`/`domain_scale`/`n_cells` keyword still wins over the preset, but a script
+  that leaves them unset can be bumped from the command line with e.g. `--quality=high` without
+  touching source.
 - `run_mode` — `:local` (default) or `:slurm`. These example scripts run their (few-point)
   mode-solve sweeps inline; `:slurm` is accepted and resolved consistently but only *acted on* by
   scripts that say so in their header. For cluster-scale sweeps use the dedicated ModeSweeps
@@ -48,6 +56,7 @@ Base.@kwdef struct ExampleSettings
     n_dense::Int = 400
     n_eme_freqs::Int = 15
     n_cells::Int = 6
+    quality::Symbol = :medium
     run_mode::Symbol = :local
     slurm::Any = nothing
 end
@@ -56,8 +65,17 @@ function Base.show(io::IO, cfg::ExampleSettings)
     print(io, "ExampleSettings(resolution_scale=", cfg.resolution_scale,
           ", domain_scale=", cfg.domain_scale, ", n_freqs=", cfg.n_freqs,
           ", n_dense=", cfg.n_dense, ", n_eme_freqs=", cfg.n_eme_freqs,
-          ", n_cells=", cfg.n_cells, ", run_mode=", cfg.run_mode, ")")
+          ", n_cells=", cfg.n_cells, ", quality=", cfg.quality,
+          ", run_mode=", cfg.run_mode, ")")
 end
+
+# Bundled resolution/boundary-distance/EME-cell-count presets (see `quality` docstring above).
+const _QUALITY_PRESETS = (
+    low    = (resolution_scale = 0.5, domain_scale = 0.8, n_cells = 3),
+    medium = (resolution_scale = 1.0, domain_scale = 1.0, n_cells = 6),
+    high   = (resolution_scale = 1.5, domain_scale = 1.2, n_cells = 10),
+    ultra  = (resolution_scale = 2.5, domain_scale = 1.5, n_cells = 16),
+)
 
 # ---------------------------------------------------------------------------------------
 # kwarg / CLI / ENV resolution
@@ -70,6 +88,7 @@ const _SETTINGS_SPEC = (
     (:n_dense,           400,     s -> parse(Int, s)),
     (:n_eme_freqs,       15,      s -> parse(Int, s)),
     (:n_cells,           6,       s -> parse(Int, s)),
+    (:quality,           :medium, s -> Symbol(lowercase(s))),
     (:run_mode,          :local,  s -> Symbol(lowercase(s))),
 )
 
@@ -98,9 +117,15 @@ function _print_settings_help()
                 _cli_flag(name), _env_key(name), string(name), string(default))
     end
     println("  --help / -h            (this message)")
+    println("\n`quality` bundles resolution_scale/domain_scale/n_cells (a-la-carte still wins):")
+    for (name, vals) in pairs(_QUALITY_PRESETS)
+        @printf("  %-8s  resolution_scale=%-4s domain_scale=%-4s n_cells=%s\n",
+                name, vals.resolution_scale, vals.domain_scale, vals.n_cells)
+    end
     println("\nExamples:")
     println("  julia --project=. examples/tantala_gvd_black2021.jl --resolution-scale=2 --n-freqs=25")
     println("  OPTIMODE_N_FREQS=25 julia --project=. examples/tantala_gvd_black2021.jl")
+    println("  julia --project=. examples/tantala_gvd_black2021.jl --quality=high")
     println("See examples/README.md for the full reference.")
 end
 
@@ -118,9 +143,21 @@ function example_settings(; kwargs...)
         exit(0)
     end
     kw = Dict{Symbol,Any}(kwargs)
-    vals = Dict{Symbol,Any}()
+
+    # `quality` resolves first (same kwarg > env > cli precedence as everything else) since it
+    # picks the preset that supplies the *defaults* for resolution_scale/domain_scale/n_cells.
+    qv = haskey(kw, :quality) ? kw[:quality] : :medium
+    qev = _env_value(:quality); qev === nothing || (qv = Symbol(lowercase(qev)))
+    qcv = _cli_value(:quality); qcv === nothing || (qv = Symbol(lowercase(qcv)))
+    haskey(_QUALITY_PRESETS, qv) ||
+        throw(ArgumentError("quality must be one of $(join(keys(_QUALITY_PRESETS), ", ")), got $(repr(qv))"))
+    preset = _QUALITY_PRESETS[qv]
+
+    vals = Dict{Symbol,Any}(:quality => qv)
     for (name, default, parse_fn) in _SETTINGS_SPEC
-        v = haskey(kw, name) ? kw[name] : default
+        name === :quality && continue
+        v = haskey(preset, name) ? preset[name] : default   # preset supplies the "default" tier
+        v = haskey(kw, name) ? kw[name] : v                 # script kwarg beats the preset
         ev = _env_value(name); ev === nothing || (v = parse_fn(ev))
         cv = _cli_value(name); cv === nothing || (v = parse_fn(cv))
         vals[name] = v

--- a/examples/paper_reproductions_common.jl
+++ b/examples/paper_reproductions_common.jl
@@ -27,7 +27,8 @@ using OptiMode.ModePerturbations: effective_area_kerr, kerr_gamma,
 using LinearAlgebra
 using Printf
 
-include(joinpath(@__DIR__, "example_settings.jl"))   # ExampleSettings, example_settings, mk_grid
+isdefined(@__MODULE__, :example_settings) ||
+    include(joinpath(@__DIR__, "example_settings.jl"))   # ExampleSettings, example_settings, mk_grid
 
 const C_MS   = 299792458.0            # speed of light (m/s)
 const C_UM_FS = C_MS * 1e-9           # speed of light (µm/fs) = 0.299792458

--- a/lib/EigenmodeExpansion/src/cache.jl
+++ b/lib/EigenmodeExpansion/src/cache.jl
@@ -20,23 +20,30 @@ export cross_section_key, dedup_groups
 # compare equal, while genuinely different cross-sections do not collide.
 _q(x::Real; atol::Float64=1e-9) = round(Int, x / atol)
 
+# Canonical, quantized key fragment for one shape's own geometry fields — dispatches per
+# `GeometryPrimitives.Shape` subtype since each stores its geometry differently (`Cuboid`'s
+# centre/half-widths/axes vs. `Polygon`'s vertex list — the latter is what a sidewall-angle
+# `Trapezoid`/`Isosceles` rib actually constructs, see designer_dichroic_linbo3_litao3.jl).
+# Add a new branch here for any further `GeometryPrimitives.Shape` subtype used in a
+# `CrossSection`; the generic fallback keys on the shape's own `Base.hash`, which is exact for
+# a bit-identical shape but won't dedup two structurally-equal-but-distinct shape instances.
+_shape_key(b::GeometryPrimitives.Cuboid; atol::Float64) =
+    (:Cuboid, Tuple(_q.(b.c; atol)), Tuple(_q.(2 .* b.r; atol)), Tuple(_q.(vec(Matrix(b.p)); atol)))
+_shape_key(b::GeometryPrimitives.Polygon; atol::Float64) =
+    (:Polygon, Tuple(_q.(vec(Matrix(b.v)); atol)))
+_shape_key(b; atol::Float64) = (:Other, hash(b))
+
 """
     cross_section_key(cs::CrossSection; atol=1e-9) -> key
 
-A hashable, `==`-comparable canonical key for a [`CrossSection`](@ref): two cells with
-equal keys have the same shapes (each `Cuboid`'s centre, half-widths and axes, quantised
-to `atol` μm) in the same order with the same material indices, hence an identical
-smoothed dielectric on a given grid. Used by [`dedup_groups`](@ref) to solve each unique
-cross-section's modes only once.
+A hashable, `==`-comparable canonical key for a [`CrossSection`](@ref): two cells with equal
+keys have the same shapes (geometry quantised to `atol` μm — see [`_shape_key`](@ref) for the
+per-shape-type field lists) in the same order with the same material indices, hence an
+identical smoothed dielectric on a given grid. Used by [`dedup_groups`](@ref) to solve each
+unique cross-section's modes only once.
 """
 function cross_section_key(cs::CrossSection; atol::Float64=1e-9)
-    shape_keys = map(cs.shapes) do ms
-        b = ms.shape                                   # GeometryPrimitives.Cuboid
-        c = Tuple(_q.(b.c; atol))                      # centre
-        r = Tuple(_q.(2 .* b.r; atol))                 # full widths (r = half-widths)
-        a = Tuple(_q.(vec(Matrix(b.p)); atol))         # axis matrix
-        (c, r, a)
-    end
+    shape_keys = map(ms -> _shape_key(ms.shape; atol), cs.shapes)
     return (Tuple(shape_keys), Tuple(cs.minds))
 end
 


### PR DESCRIPTION
## Summary

- Generalize the AD+EME dichroic-filter designer from a single (material, target λC) point design into a reusable, geometry-agnostic driver (`dichroic_designer_common.jl`: `DichroicGeometry`, `run_dichroic_case`, `run_dichroic_sweep`) that sweeps an array of cutoff targets and produces per-case reports (AD trace, isolated dispersion, EME taper-length search, dense broadband transmission spectrum, TE00 field plots) plus a per-configuration summary grid (matching wavelength axes, target λC marked).
- `designer_dichroic_si3n4.jl`: rewritten to sweep λC = 1000–1500 nm (11 targets, 50 nm step) × 6 Si₃N₄ core thicknesses (40/60/80/100/200/400 nm), with thickness-scaled design-space bounds and grids for the much-wider structures thin cores need.
- `designer_dichroic_linbo3_litao3.jl` (new): same λC sweep for X-cut LiNbO₃ and LiTaO₃ rib-on-slab waveguides with a genuine 65° sidewall (`GeometryPrimitives.Trapezoid`), fully encapsulated in SiO₂, across 3 (full/slab thickness) stacks each (400/100, 500/150, 600/200 nm).
- `example_settings.jl`: add a bundled `quality` preset (`low`/`medium`/`high`/`ultra`) for `resolution_scale`/`domain_scale`/`n_cells` together, settable via `--quality=`/`OPTIMODE_QUALITY`, on top of the existing a-la-carte knobs (preset sits below CLI/env/script-kwarg in precedence).
- `lib/EigenmodeExpansion/src/cache.jl`: fix `cross_section_key`/dedup to dispatch per shape type instead of hardcoding `Cuboid` fields — the sidewall-angle rib's `Trapezoid`/`Polygon` shape crashed the EME cell-dedup cache (`type Polygon has no field c`) the first time a non-Cuboid shape was used in a `CrossSection`.
- `paper_reproductions_common.jl`: include-guard fix for a fatal duplicate-include when a script pulls in both `designer_common.jl` and `eme_reproductions_common.jl`.

## Validation

Both designer scripts were run to completion end-to-end (132 total cases at the `low` quality preset for tractable turnaround in this session):
- LiNbO₃/LiTaO₃: all 66 cases converge to clean, well-separated dichroic crossings tracking the target λC across the full sweep.
- Si₃N₄: 400 nm reproduces the previously-validated point design near its original tuning point; thinner cores (especially 40 nm) mostly need `--quality=high`/`ultra` (slower) to actually resolve a real crossing with these heuristic wide-waveguide starting points — documented as a caveat in the script header.

Per-case reports, trace CSVs, and sweep-summary CSVs/grids were generated in `examples/paper_reproduction_output/` (gitignored) and spot-checked visually.

## Test plan

- [x] Both designer scripts run end-to-end without errors at `--quality=low`
- [x] Summary grids show physically sensible, target-tracking dichroic responses for LiNbO₃/LiTaO₃ and for Si₃N₄ near its validated point
- [ ] Optional follow-up: rerun thin-Si₃N₄ cases at `--quality=high`/`ultra` for production-fidelity crossings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ayn1B3fv797FbNBY2qiSXX)_